### PR TITLE
Update cargo metadata

### DIFF
--- a/tarpc/Cargo.toml
+++ b/tarpc/Cargo.toml
@@ -3,7 +3,12 @@ name = "tarpc"
 version = "0.1.0"
 authors = ["Adam Wright <adam.austin.wright@gmail.com>", "Tim Kuehn <timothy.j.kuehn@gmail.com>"]
 license = "MIT"
-description = "tarpc is an RPC framework for rust with a focus on ease of use."
+documentation = "https://google.github.io/tarpc"
+homepage = "https://github.com/google/tarpc"
+repository = "https://github.com/google/tarpc"
+keywords = ["rpc", "protocol", "framework", "remote", "procedure", "serialize"]
+readme = "README.md"
+description = "An RPC framework for Rust with a focus on ease of use."
 
 [dependencies]
 bincode = "*"


### PR DESCRIPTION
To make sure crates.io shows all the proper links.