### PR TITLE
[Breaking] Renamings and refactorings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,12 @@ fn main() {
 }
 ```
 
-The `service!` macro expands to a collection of items that collectively form an
-rpc service. In the above example, the macro is called within the
-`hello_service` module. This module will contain a `Client` type, a `Service`
-trait, and a `serve` function. `serve` can be used to start a server listening
-on a tcp port. A `Client` (or `AsyncClient`) can connect to such a service. Any
-type implementing the `Service` trait can be passed to `serve`. These generated
-types are specific to the echo service, and make it easy and ergonomic to write
-servers without dealing with sockets or serialization directly. See the
+The `service!` macro expands to a collection of items that collectively form an rpc service. In the
+above example, the macro is called within the `hello_service` module. This module will contain a
+`Client` (and `AsyncClient`) type, and a `Service` trait. The trait provides `default fn`s for
+starting the service: `spawn` and `spawn_with_config`, which start the service listening on a tcp
+port. A `Client` (or `AsyncClient`) can connect to such a service. These generated types make it
+easy and ergonomic to write servers without dealing with sockets or serialization directly. See the
 tarpc_examples package for more sophisticated examples.
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ impl hello_service::Service for HelloService {
 }
 
 fn main() {
-    let server_handle = hello_service::serve("0.0.0.0:0", HelloService, None).unwrap();
+    let server_handle = HelloService.spawn("0.0.0.0:0").unwrap();
     let client = hello_service::Client::new(server_handle.local_addr(), None).unwrap();
     assert_eq!("Hello, Mom!", client.hello("Mom".into()).unwrap());
     drop(client);

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ items expanded by a `service!` invocation.
 
 ## Additional Features
 - Concurrent requests from a single client.
+- Any type that `impl`s `serde`'s Serialize` and `Deserialize` can be used in the rpc signatures.
 - Attributes can be specified on rpc methods. These will be included on both the `Service` trait
   methods as well as on the `Client`'s stub methods.
 - Just like regular fns, the return type can be left off when it's `-> ()`.

--- a/tarpc/Cargo.toml
+++ b/tarpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tarpc"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Adam Wright <adam.austin.wright@gmail.com>", "Tim Kuehn <timothy.j.kuehn@gmail.com>"]
 license = "MIT"
 documentation = "https://google.github.io/tarpc"

--- a/tarpc/src/lib.rs
+++ b/tarpc/src/lib.rs
@@ -8,7 +8,7 @@
 //! Example usage:
 //!
 //! ```
-//! # #[macro_use] extern crate tarpc;
+//! #[macro_use] extern crate tarpc;
 //! mod my_server {
 //!     service! {
 //!         rpc hello(name: String) -> String;
@@ -31,11 +31,8 @@
 //!
 //! fn main() {
 //!     let addr = "127.0.0.1:9000";
-//!     let shutdown = my_server::serve(addr,
-//!                                     Server,
-//!                                     Some(Duration::from_secs(30)))
-//!                               .unwrap();
-//!     let client = Client::new(addr, None).unwrap();
+//!     let shutdown = Server.spawn(addr).unwrap();
+//!     let client = Client::new(addr).unwrap();
 //!     assert_eq!(3, client.add(1, 2).unwrap());
 //!     assert_eq!("Hello, Mom!".to_string(),
 //!                client.hello("Mom".to_string()).unwrap());
@@ -63,4 +60,4 @@ pub mod protocol;
 /// Provides the macro used for constructing rpc services and client stubs.
 pub mod macros;
 
-pub use protocol::{Error, Result, ServeHandle};
+pub use protocol::{Config, Error, Result, ServeHandle};

--- a/tarpc/src/macros.rs
+++ b/tarpc/src/macros.rs
@@ -218,17 +218,22 @@ macro_rules! impl_deserialize {
 /// # }
 /// ```
 ///
+/// There are two rpc names reserved for the default fns `spawn` and `spawn_with_config`.
+///
 /// Attributes can be attached to each rpc. These attributes
 /// will then be attached to the generated `Service` trait's
 /// corresponding method, as well as to the `Client` stub's rpcs methods.
 ///
 /// The following items are expanded in the enclosing module:
 ///
-/// * `Service` -- the trait defining the RPC service
+/// * `Service` -- the trait defining the RPC service. It comes with two default methods for
+///                starting the server:
+///                1. `spawn` starts the service in another thread using default configuration.
+///                2. `spawn_with_config` starts the service in another thread using the specified
+///                   `Config`.
 /// * `Client` -- a client that makes synchronous requests to the RPC server
 /// * `AsyncClient` -- a client that makes asynchronous requests to the RPC server
 /// * `Future` -- a handle for asynchronously retrieving the result of an RPC
-/// * `serve` -- the function that spawns the RPC server
 ///
 /// **Warning**: In addition to the above items, there are a few expanded items that
 /// are considered implementation details. As with the above items, shadowing

--- a/tarpc/src/macros.rs
+++ b/tarpc/src/macros.rs
@@ -299,7 +299,7 @@ macro_rules! service_inner {
         )*
     ) => {
         #[doc="Defines the RPC service"]
-        pub trait Service: Send + Sync + Sized + 'static {
+        pub trait Service: Send + Sync + Sized {
             $(
                 $(#[$attr])*
                 fn $fn_name(&self, $($arg:$in_),*) -> $out;
@@ -308,6 +308,7 @@ macro_rules! service_inner {
             #[doc="Spawn a running service."]
             fn spawn<A>(self, addr: A) -> $crate::Result<$crate::protocol::ServeHandle>
                 where A: ::std::net::ToSocketAddrs,
+                      Self: 'static,
             {
                 self.spawn_with_config(addr, $crate::Config::default())
             }
@@ -316,6 +317,7 @@ macro_rules! service_inner {
             fn spawn_with_config<A>(self, addr: A, config: $crate::Config)
                 -> $crate::Result<$crate::protocol::ServeHandle>
                 where A: ::std::net::ToSocketAddrs,
+                      Self: 'static,
             {
                 let server = ::std::sync::Arc::new(__Server(self));
                 let handle = try!($crate::protocol::Serve::spawn_with_config(server, addr, config));

--- a/tarpc/src/macros.rs
+++ b/tarpc/src/macros.rs
@@ -38,7 +38,7 @@ macro_rules! client_methods {
             if let __Reply::$fn_name(reply) = reply {
                 ::std::result::Result::Ok(reply)
             } else {
-                panic!("Incorrect reply variant returned from protocol::Clientrpc; expected `{}`, \
+                panic!("Incorrect reply variant returned from rpc; expected `{}`, \
                        but got {:?}",
                        stringify!($fn_name),
                        reply);
@@ -79,8 +79,8 @@ macro_rules! async_client_methods {
                 if let __Reply::$fn_name(reply) = reply {
                     reply
                 } else {
-                    panic!("Incorrect reply variant returned from protocol::Clientrpc; expected \
-                           `{}`, but got {:?}",
+                    panic!("Incorrect reply variant returned from rpc; expected `{}`, but got \
+                           {:?}",
                            stringify!($fn_name),
                            reply);
                 }

--- a/tarpc/src/protocol/mod.rs
+++ b/tarpc/src/protocol/mod.rs
@@ -56,7 +56,7 @@ impl convert::From<io::Error> for Error {
 }
 
 /// Configuration for client and server.
-#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Default)]
 pub struct Config {
     /// Request/Response timeout between packet delivery.
     pub timeout: Option<Duration>,

--- a/tarpc/src/protocol/mod.rs
+++ b/tarpc/src/protocol/mod.rs
@@ -56,7 +56,7 @@ impl convert::From<io::Error> for Error {
 }
 
 /// Configuration for client and server.
-#[derive(Clone, Copy, Debug, Default, Hash, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Config {
     /// Request/Response timeout between packet delivery.
     pub timeout: Option<Duration>,

--- a/tarpc/src/protocol/packet.rs
+++ b/tarpc/src/protocol/packet.rs
@@ -32,7 +32,7 @@ struct MapVisitor<'a, T: 'a> {
     state: u8,
 }
 
-impl <'a, T: Serialize> ser::MapVisitor for MapVisitor<'a, T> {
+impl<'a, T: Serialize> ser::MapVisitor for MapVisitor<'a, T> {
     #[inline]
     fn visit<S>(&mut self, serializer: &mut S) -> Result<Option<()>, S::Error>
         where S: Serializer
@@ -46,9 +46,7 @@ impl <'a, T: Serialize> ser::MapVisitor for MapVisitor<'a, T> {
                 self.state += 1;
                 Ok(Some(try!(serializer.visit_struct_elt(MESSAGE, &self.value.message))))
             }
-            _ => {
-                Ok(None)
-            }
+            _ => Ok(None),
         }
     }
 

--- a/tarpc_examples/src/lib.rs
+++ b/tarpc_examples/src/lib.rs
@@ -37,12 +37,12 @@ mod benchmark {
     // Prevents resource exhaustion when benching
     lazy_static! {
         static ref HANDLE: Arc<Mutex<ServeHandle>> = {
-            let handle = serve("localhost:0", HelloServer, None).unwrap();
+            let handle = HelloServer.spawn("localhost:0").unwrap();
             Arc::new(Mutex::new(handle))
         };
         static ref CLIENT: Arc<Mutex<AsyncClient>> = {
             let addr = HANDLE.lock().unwrap().local_addr().clone();
-            let client = AsyncClient::new(addr, None).unwrap();
+            let client = AsyncClient::new(addr).unwrap();
             Arc::new(Mutex::new(client))
         };
     }


### PR DESCRIPTION
* Add a Config struct. `Client::new(addr, duration)` => `Client::new(addr, config)`
* `serve(addr, server, config)` => `server.spawn_with_config(addr, config)`
* Also added `server.spawn(addr)`

Fixes #18 