### PR TITLE
[Breaking] Add support for arbitrary transports.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,17 +56,18 @@ fn main() {
 
 The `service!` macro expands to a collection of items that collectively form an rpc service. In the
 above example, the macro is called within the `hello_service` module. This module will contain a
-`Client` (and `AsyncClient`) type, and a `Service` trait. The trait provides `default fn`s for
-starting the service: `spawn` and `spawn_with_config`, which start the service listening on a tcp
-port. A `Client` (or `AsyncClient`) can connect to such a service. These generated types make it
-easy and ergonomic to write servers without dealing with sockets or serialization directly. See the
-tarpc_examples package for more sophisticated examples.
+`Client` (and `AsyncClient`) type, and a `Service` trait. The trait provides default `fn`s for
+starting the service: `spawn` and `spawn_with_config`, which start the service listening over an
+arbitrary transport. A `Client` (or `AsyncClient`) can connect to such a service. These generated
+types make it easy and ergonomic to write servers without dealing with sockets or serialization
+directly. See the tarpc_examples package for more sophisticated examples.
 
 ## Documentation
 Use `cargo doc` as you normally would to see the documentation created for all
 items expanded by a `service!` invocation.
 
 ## Additional Features
+- Connect over any transport that `impl`s the `Transport` trait.
 - Concurrent requests from a single client.
 - Any type that `impl`s `serde`'s `Serialize` and `Deserialize` can be used in the rpc signatures.
 - Attributes can be specified on rpc methods. These will be included on both the `Service` trait

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ impl HelloService for HelloServer {
 
 fn main() {
     let server_handle = HelloServer.spawn("0.0.0.0:0").unwrap();
-    let client = hello_service::Client::new(server_handle.local_addr()).unwrap();
+    let client = hello_service::Client::new(server_handle.dialer()).unwrap();
     assert_eq!("Hello, Mom!", client.hello("Mom".into()).unwrap());
     drop(client);
     server_handle.shutdown();

--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ impl HelloService for HelloServer {
 }
 
 fn main() {
-    let server_handle = HelloServer.spawn("0.0.0.0:0").unwrap();
-    let client = hello_service::Client::new(server_handle.dialer()).unwrap();
+    let addr = "localhost:10000";
+    let server_handle = HelloServer.spawn(addr).unwrap();
+    let client = hello_service::Client::new(addr).unwrap();
     assert_eq!("Hello, Mom!", client.hello("Mom".into()).unwrap());
     drop(client);
     server_handle.shutdown();

--- a/tarpc/Cargo.toml
+++ b/tarpc/Cargo.toml
@@ -13,8 +13,8 @@ description = "An RPC framework for Rust with a focus on ease of use."
 [dependencies]
 bincode = "^0.4.0"
 log = "^0.3.5"
-scoped-pool = "^0.1.5"
-serde = "^0.6.14"
+scoped-pool = "^0.1.8"
+serde = "^0.6.15"
 unix_socket = "^0.5.0"
 
 [dev-dependencies]

--- a/tarpc/Cargo.toml
+++ b/tarpc/Cargo.toml
@@ -20,3 +20,4 @@ unix_socket = "^0.5.0"
 [dev-dependencies]
 lazy_static = "^0.1.15"
 env_logger = "^0.3.2"
+tempdir = "^0.3.4"

--- a/tarpc/Cargo.toml
+++ b/tarpc/Cargo.toml
@@ -15,6 +15,7 @@ bincode = "^0.4.0"
 log = "^0.3.5"
 scoped-pool = "^0.1.5"
 serde = "^0.6.14"
+unix_socket = "^0.5.0"
 
 [dev-dependencies]
 lazy_static = "^0.1.15"

--- a/tarpc/src/lib.rs
+++ b/tarpc/src/lib.rs
@@ -48,6 +48,7 @@ extern crate bincode;
 #[macro_use]
 extern crate log;
 extern crate scoped_pool;
+extern crate unix_socket;
 
 macro_rules! pos {
     () => (concat!(file!(), ":", line!()))
@@ -60,5 +61,7 @@ pub mod protocol;
 /// Provides the macro used for constructing rpc services and client stubs.
 pub mod macros;
 
-pub use protocol::{Config, Dialer, Error, Listener, Result, ServeHandle, Stream, TcpDialer,
-                   TcpDialerExt, TcpTransport, Transport};
+/// Provides transport traits and implementations.
+pub mod transport;
+
+pub use protocol::{Config, Error, Result, ServeHandle};

--- a/tarpc/src/lib.rs
+++ b/tarpc/src/lib.rs
@@ -60,4 +60,5 @@ pub mod protocol;
 /// Provides the macro used for constructing rpc services and client stubs.
 pub mod macros;
 
-pub use protocol::{Config, Error, Result, ServeHandle};
+pub use protocol::{Config, Dialer, Error, Listener, Result, ServeHandle, Stream, TcpDialer,
+                   TcpDialerExt, TcpTransport, Transport};

--- a/tarpc/src/lib.rs
+++ b/tarpc/src/lib.rs
@@ -31,13 +31,13 @@
 //!
 //! fn main() {
 //!     let addr = "127.0.0.1:9000";
-//!     let shutdown = Server.spawn(addr).unwrap();
-//!     let client = Client::new(addr).unwrap();
+//!     let serve_handle = Server.spawn(addr).unwrap();
+//!     let client = Client::new(serve_handle.dialer()).unwrap();
 //!     assert_eq!(3, client.add(1, 2).unwrap());
 //!     assert_eq!("Hello, Mom!".to_string(),
 //!                client.hello("Mom".to_string()).unwrap());
 //!     drop(client);
-//!     shutdown.shutdown();
+//!     serve_handle.shutdown();
 //! }
 //! ```
 

--- a/tarpc/src/lib.rs
+++ b/tarpc/src/lib.rs
@@ -30,8 +30,7 @@
 //! }
 //!
 //! fn main() {
-//!     let addr = "127.0.0.1:9000";
-//!     let serve_handle = Server.spawn(addr).unwrap();
+//!     let serve_handle = Server.spawn("localhost:0").unwrap();
 //!     let client = Client::new(serve_handle.dialer()).unwrap();
 //!     assert_eq!(3, client.add(1, 2).unwrap());
 //!     assert_eq!("Hello, Mom!".to_string(),

--- a/tarpc/src/macros.rs
+++ b/tarpc/src/macros.rs
@@ -386,7 +386,8 @@ macro_rules! service_inner {
 
         #[allow(unused)]
         #[doc="The client stub that makes RPC calls to the server."]
-        pub struct Client<S: $crate::Stream>($crate::protocol::Client<__Request, __Reply, S>);
+        pub struct Client<S = ::std::net::TcpStream>($crate::protocol::Client<__Request, __Reply, S>)
+            where S: $crate::Stream;
 
         impl Client<::std::net::TcpStream> {
             pub fn new<A>(addr: A) -> $crate::Result<Self>
@@ -396,7 +397,9 @@ macro_rules! service_inner {
             }
         }
 
-        impl<S: $crate::Stream> Client<S> {
+        impl<S> Client<S>
+            where S: $crate::Stream
+        {
             #[allow(unused)]
             #[doc="Create a new client with default configuration that connects to the given \
                    address."]
@@ -427,7 +430,8 @@ macro_rules! service_inner {
 
         #[allow(unused)]
         #[doc="The client stub that makes asynchronous RPC calls to the server."]
-        pub struct AsyncClient<S: $crate::Stream>($crate::protocol::Client<__Request, __Reply, S>);
+        pub struct AsyncClient<S = ::std::net::TcpStream>($crate::protocol::Client<__Request, __Reply, S>)
+            where S: $crate::Stream;
 
         impl AsyncClient<::std::net::TcpStream> {
             #[allow(unused)]
@@ -440,7 +444,8 @@ macro_rules! service_inner {
             }
         }
 
-        impl<S: $crate::Stream> AsyncClient<S> {
+        impl<S> AsyncClient<S>
+            where S: $crate::Stream {
             #[allow(unused)]
             #[doc="Create a new asynchronous client that connects to the given address."]
             pub fn with_config<D>(dialer: D, config: $crate::Config) -> $crate::Result<Self>
@@ -466,7 +471,8 @@ macro_rules! service_inner {
         }
 
         #[allow(unused)]
-        struct __Server<S: 'static + Service>(S);
+        struct __Server<S>(S)
+            where S: 'static + Service;
 
         impl<S> $crate::protocol::Serve for __Server<S>
             where S: 'static + Service

--- a/tarpc/src/macros.rs
+++ b/tarpc/src/macros.rs
@@ -316,17 +316,17 @@ macro_rules! service_inner {
 
             #[doc="Spawn a running service."]
             fn spawn<A>(self, addr: A)
-                -> $crate::Result<$crate::protocol::ServeHandle<$crate::TcpDialer<::std::net::SocketAddr>>>
+                -> $crate::Result<$crate::protocol::ServeHandle<$crate::transport::tcp::TcpDialer<::std::net::SocketAddr>>>
                 where A: ::std::net::ToSocketAddrs,
                       Self: 'static,
             {
-                self.spawn_with_config($crate::TcpTransport(addr), $crate::Config::default())
+                self.spawn_with_config($crate::transport::tcp::TcpTransport(addr), $crate::Config::default())
             }
 
             #[doc="Spawn a running service."]
             fn spawn_with_config<T>(self, addr: T, config: $crate::Config)
-                -> $crate::Result<$crate::protocol::ServeHandle<<T::Listener as $crate::Listener>::Dialer>>
-                where T: $crate::Transport,
+                -> $crate::Result<$crate::protocol::ServeHandle<<T::Listener as $crate::transport::Listener>::Dialer>>
+                where T: $crate::transport::Transport,
                       Self: 'static,
             {
                 let server = ::std::sync::Arc::new(__Server(self));
@@ -387,18 +387,18 @@ macro_rules! service_inner {
         #[allow(unused)]
         #[doc="The client stub that makes RPC calls to the server."]
         pub struct Client<S = ::std::net::TcpStream>($crate::protocol::Client<__Request, __Reply, S>)
-            where S: $crate::Stream;
+            where S: $crate::transport::Stream;
 
         impl Client<::std::net::TcpStream> {
             pub fn new<A>(addr: A) -> $crate::Result<Self>
                 where A: ::std::net::ToSocketAddrs,
             {
-                Self::with_config($crate::TcpDialer(addr), $crate::Config::default())
+                Self::with_config($crate::transport::tcp::TcpDialer(addr), $crate::Config::default())
             }
         }
 
         impl<S> Client<S>
-            where S: $crate::Stream
+            where S: $crate::transport::Stream
         {
             #[allow(unused)]
             #[doc="Create a new client with default configuration that connects to the given \
@@ -407,7 +407,7 @@ macro_rules! service_inner {
             #[doc="Create a new client with the specified configuration that connects to the \
                    given address."]
             pub fn with_config<D>(dialer: D, config: $crate::Config) -> $crate::Result<Self>
-                where D: $crate::Dialer<Stream=S>,
+                where D: $crate::transport::Dialer<Stream=S>,
             {
                 let inner = try!($crate::protocol::Client::with_config(dialer, config));
                 ::std::result::Result::Ok(Client(inner))
@@ -431,7 +431,7 @@ macro_rules! service_inner {
         #[allow(unused)]
         #[doc="The client stub that makes asynchronous RPC calls to the server."]
         pub struct AsyncClient<S = ::std::net::TcpStream>($crate::protocol::Client<__Request, __Reply, S>)
-            where S: $crate::Stream;
+            where S: $crate::transport::Stream;
 
         impl AsyncClient<::std::net::TcpStream> {
             #[allow(unused)]
@@ -440,16 +440,16 @@ macro_rules! service_inner {
             pub fn new<A>(addr: A) -> $crate::Result<AsyncClient<::std::net::TcpStream>>
                 where A: ::std::net::ToSocketAddrs,
             {
-                Self::with_config($crate::TcpDialer(addr), $crate::Config::default())
+                Self::with_config($crate::transport::tcp::TcpDialer(addr), $crate::Config::default())
             }
         }
 
         impl<S> AsyncClient<S>
-            where S: $crate::Stream {
+            where S: $crate::transport::Stream {
             #[allow(unused)]
             #[doc="Create a new asynchronous client that connects to the given address."]
             pub fn with_config<D>(dialer: D, config: $crate::Config) -> $crate::Result<Self>
-                where D: $crate::Dialer<Stream=S>
+                where D: $crate::transport::Dialer<Stream=S>
             {
                 let inner = try!($crate::protocol::Client::with_config(dialer, config));
                 ::std::result::Result::Ok(AsyncClient(inner))

--- a/tarpc/src/macros.rs
+++ b/tarpc/src/macros.rs
@@ -529,7 +529,6 @@ mod syntax_test {
 mod functional_test {
     extern crate env_logger;
     extern crate tempdir;
-    use Config;
     use transport::unix::UnixTransport;
 
     service! {

--- a/tarpc/src/macros.rs
+++ b/tarpc/src/macros.rs
@@ -522,6 +522,7 @@ mod syntax_test {
 #[cfg(test)]
 mod functional_test {
     extern crate env_logger;
+    extern crate tempdir;
     use Config;
     use transport::unix::UnixTransport;
 
@@ -583,16 +584,15 @@ mod functional_test {
 
     #[test]
     fn async_try_clone_unix() {
-        let handle = Server.spawn_with_config(UnixTransport("/tmp/test"),
+        let temp_dir = tempdir::TempDir::new(module_path!()).unwrap();
+        let temp_file = temp_dir.path().join("async_try_clone_unix.tmp");
+        let handle = Server.spawn_with_config(UnixTransport(temp_file),
                                               Config::default()).unwrap();
         let client1 = AsyncClient::with_config(handle.dialer(),
                                                Config::default()).unwrap();
         let client2 = client1.try_clone().unwrap();
         assert_eq!(3, client1.add(1, 2).get().unwrap());
         assert_eq!(3, client2.add(1, 2).get().unwrap());
-        drop(client1);
-        drop(client2);
-        handle.shutdown();
     }
 
     // Tests that a server can be wrapped in an Arc; no need to run, just compile

--- a/tarpc/src/macros.rs
+++ b/tarpc/src/macros.rs
@@ -329,7 +329,7 @@ macro_rules! service_inner {
                 where T: $crate::transport::Transport,
                       Self: 'static,
             {
-                let server = ::std::sync::Arc::new(__Server(self));
+                let server = __Server(self);
                 let handle = try!($crate::protocol::Serve::spawn_with_config(server, transport, config));
                 ::std::result::Result::Ok(handle)
             }

--- a/tarpc/src/protocol/client.rs
+++ b/tarpc/src/protocol/client.rs
@@ -18,7 +18,7 @@ use transport::{Dialer, Stream};
 /// A client stub that connects to a server to run rpcs.
 pub struct Client<Request, Reply, S>
     where Request: serde::ser::Serialize,
-          S: Stream,
+          S: Stream
 {
     // The guard is in an option so it can be joined in the drop fn
     reader_guard: Arc<Option<thread::JoinHandle<()>>>,
@@ -30,12 +30,12 @@ pub struct Client<Request, Reply, S>
 impl<Request, Reply, S> Client<Request, Reply, S>
     where Request: serde::ser::Serialize + Send + 'static,
           Reply: serde::de::Deserialize + Send + 'static,
-          S: Stream,
+          S: Stream
 {
     /// Create a new client that connects to `addr`. The client uses the given timeout
     /// for both reads and writes.
     pub fn new<D>(dialer: D) -> io::Result<Self>
-        where D: Dialer<Stream=S>,
+        where D: Dialer<Stream = S>
     {
         Self::with_config(dialer, Config::default())
     }
@@ -43,7 +43,7 @@ impl<Request, Reply, S> Client<Request, Reply, S>
     /// Create a new client that connects to `addr`. The client uses the given timeout
     /// for both reads and writes.
     pub fn with_config<D>(dialer: D, config: Config) -> io::Result<Self>
-        where D: Dialer<Stream=S>,
+        where D: Dialer<Stream = S>
     {
         let stream = try!(dialer.dial());
         try!(stream.set_read_timeout(config.timeout));
@@ -105,7 +105,7 @@ impl<Request, Reply, S> Client<Request, Reply, S>
 
 impl<Request, Reply, S> Drop for Client<Request, Reply, S>
     where Request: serde::ser::Serialize,
-          S: Stream,
+          S: Stream
 {
     fn drop(&mut self) {
         debug!("Dropping Client.");
@@ -193,11 +193,11 @@ impl<Reply> RpcFutures<Reply> {
 }
 
 fn write<Request, Reply, S>(outbound: Receiver<(Request, Sender<Result<Reply>>)>,
-                         requests: Arc<Mutex<RpcFutures<Reply>>>,
-                         stream: S)
+                            requests: Arc<Mutex<RpcFutures<Reply>>>,
+                            stream: S)
     where Request: serde::Serialize,
           Reply: serde::Deserialize,
-          S: Stream,
+          S: Stream
 {
     let mut next_id = 0;
     let mut stream = BufWriter::new(stream);
@@ -248,7 +248,7 @@ fn write<Request, Reply, S>(outbound: Receiver<(Request, Sender<Result<Reply>>)>
 
 fn read<Reply, S>(requests: Arc<Mutex<RpcFutures<Reply>>>, stream: S)
     where Reply: serde::Deserialize,
-          S: Stream,
+          S: Stream
 {
     let mut stream = BufReader::new(stream);
     loop {

--- a/tarpc/src/protocol/client.rs
+++ b/tarpc/src/protocol/client.rs
@@ -13,7 +13,9 @@ use std::sync::{Arc, Mutex};
 use std::sync::mpsc::{Receiver, Sender, channel};
 use std::thread;
 
-use super::{Config, Deserialize, Dialer, Error, Packet, Result, Serialize, Stream, TcpDialer};
+use super::{Config, Deserialize, Error, Packet, Result, Serialize};
+use transport::{Dialer, Stream};
+use transport::tcp::TcpDialer;
 
 /// A client stub that connects to a server to run rpcs.
 pub struct Client<Request, Reply, S: Stream>

--- a/tarpc/src/protocol/mod.rs
+++ b/tarpc/src/protocol/mod.rs
@@ -153,7 +153,8 @@ pub trait TcpDialerExt {
 }
 
 /// Connects to a socket address.
-pub struct TcpDialer<A: ToSocketAddrs>(pub A);
+pub struct TcpDialer<A = SocketAddr>(pub A)
+    where A: ToSocketAddrs;
 impl<A: ToSocketAddrs> Dialer for TcpDialer<A> {
     type Stream = TcpStream;
     fn dial(&self) -> io::Result<TcpStream> {

--- a/tarpc/src/protocol/mod.rs
+++ b/tarpc/src/protocol/mod.rs
@@ -181,9 +181,7 @@ mod test {
         let _ = env_logger::init();
         let server = Arc::new(Server::new());
         let serve_handle = server.spawn_with_config(TcpTransport("localhost:0"),
-                                                    Config {
-                                                        timeout: Some(Duration::new(0, 10)),
-                                                    })
+                                                    Config { timeout: Some(Duration::new(0, 10)) })
                                  .unwrap();
         let client: Client<(), u64, _> = Client::new(serve_handle.dialer()).unwrap();
         let thread = thread::spawn(move || serve_handle.shutdown());
@@ -196,9 +194,7 @@ mod test {
         let _ = env_logger::init();
         let server = Arc::new(Server::new());
         let serve_handle = server.spawn_with_config(TcpTransport("localhost:0"),
-                                                    Config {
-                                                        timeout: test_timeout(),
-                                                    })
+                                                    Config { timeout: test_timeout() })
                                  .unwrap();
         let client: Arc<Client<(), u64, _>> = Arc::new(Client::new(serve_handle.dialer()).unwrap());
         client.rpc(()).unwrap();

--- a/tarpc/src/protocol/server.rs
+++ b/tarpc/src/protocol/server.rs
@@ -150,7 +150,7 @@ struct Server<'a, S: 'a, L>
 
 impl<'a, S, L> Server<'a, S, L>
     where S: Serve + 'static,
-          L: Listener,
+          L: Listener
 {
     fn serve<'b>(self, scope: &Scope<'b>)
         where 'a: 'b

--- a/tarpc/src/protocol/server.rs
+++ b/tarpc/src/protocol/server.rs
@@ -17,7 +17,7 @@ use transport::tcp::TcpDialer;
 
 struct ConnectionHandler<'a, S, St>
     where S: Serve,
-          St: Stream,
+          St: Stream
 {
     read_stream: BufReader<St>,
     write_stream: BufWriter<St>,
@@ -27,7 +27,7 @@ struct ConnectionHandler<'a, S, St>
 
 impl<'a, S, St> ConnectionHandler<'a, S, St>
     where S: Serve,
-          St: Stream,
+          St: Stream
 {
     fn handle_conn<'b>(&'b mut self, scope: &Scope<'b>) -> Result<()> {
         let ConnectionHandler {
@@ -219,19 +219,20 @@ pub trait Serve: Send + Sync + Sized {
     fn serve(&self, request: Self::Request) -> Self::Reply;
 
     /// spawn
-    fn spawn<T>(self, transport: T)
-        -> io::Result<ServeHandle<<T::Listener as Listener>::Dialer>>
+    fn spawn<T>(self, transport: T) -> io::Result<ServeHandle<<T::Listener as Listener>::Dialer>>
         where T: Transport,
-              Self: 'static,
+              Self: 'static
     {
         self.spawn_with_config(transport, Config::default())
     }
 
     /// spawn
-    fn spawn_with_config<T>(self, transport: T, config: Config)
-        -> io::Result<ServeHandle<<T::Listener as Listener>::Dialer>>
+    fn spawn_with_config<T>(self,
+                            transport: T,
+                            config: Config)
+                            -> io::Result<ServeHandle<<T::Listener as Listener>::Dialer>>
         where T: Transport,
-              Self: 'static,
+              Self: 'static
     {
         let listener = try!(transport.bind());
         let dialer = try!(listener.dialer());

--- a/tarpc/src/protocol/server.rs
+++ b/tarpc/src/protocol/server.rs
@@ -12,8 +12,9 @@ use std::sync::mpsc::{Receiver, Sender, TryRecvError, channel};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use std::thread::{self, JoinHandle};
-use super::{Config, Deserialize, Dialer, Error, Listener, Packet, Result, Serialize, Stream,
-            TcpDialer, TcpDialerExt, TcpTransport, Transport};
+use super::{Config, Deserialize, Error, Packet, Result, Serialize};
+use transport::{Dialer, Listener, Stream, Transport};
+use transport::tcp::{TcpDialer, TcpTransport};
 
 struct ConnectionHandler<'a, S, St>
     where S: Serve,
@@ -126,7 +127,7 @@ impl<D> ServeHandle<D>
     }
 
     /// Returns the socket being listened on when the dialer is a `TcpDialer`.
-    pub fn local_addr(&self) -> &D::Addr where D: TcpDialerExt {
+    pub fn local_addr(&self) -> &D::Addr {
         self.dialer().addr()
     }
 

--- a/tarpc/src/protocol/server.rs
+++ b/tarpc/src/protocol/server.rs
@@ -104,7 +104,7 @@ impl<'a, S, St> ConnectionHandler<'a, S, St>
 }
 
 /// Provides methods for blocking until the server completes,
-pub struct ServeHandle<D>
+pub struct ServeHandle<D = TcpDialer>
     where D: Dialer
 {
     tx: Sender<()>,

--- a/tarpc/src/protocol/server.rs
+++ b/tarpc/src/protocol/server.rs
@@ -138,7 +138,9 @@ impl<D> ServeHandle<D>
     }
 }
 
-struct Server<'a, S: 'a, L: Listener> {
+struct Server<'a, S: 'a, L>
+    where L: Listener
+{
     server: &'a S,
     listener: L,
     read_timeout: Option<Duration>,
@@ -146,8 +148,9 @@ struct Server<'a, S: 'a, L: Listener> {
     shutdown: &'a AtomicBool,
 }
 
-impl<'a, S: 'a, L: Listener> Server<'a, S, L>
-    where S: Serve + 'static
+impl<'a, S, L> Server<'a, S, L>
+    where S: Serve + 'static,
+          L: Listener,
 {
     fn serve<'b>(self, scope: &Scope<'b>)
         where 'a: 'b
@@ -201,7 +204,9 @@ impl<'a, S: 'a, L: Listener> Server<'a, S, L>
     }
 }
 
-impl<'a, S, L: Listener> Drop for Server<'a, S, L> {
+impl<'a, S, L> Drop for Server<'a, S, L>
+    where L: Listener
+{
     fn drop(&mut self) {
         debug!("Shutting down connection handlers.");
         self.shutdown.store(true, Ordering::SeqCst);

--- a/tarpc/src/protocol/server.rs
+++ b/tarpc/src/protocol/server.rs
@@ -7,24 +7,27 @@ use serde;
 use scoped_pool::{Pool, Scope};
 use std::fmt;
 use std::io::{self, BufReader, BufWriter};
-use std::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
+use std::net::{SocketAddr, ToSocketAddrs};
 use std::sync::mpsc::{Receiver, Sender, TryRecvError, channel};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use std::thread::{self, JoinHandle};
-use super::{Config, Deserialize, Error, Packet, Result, Serialize};
+use super::{Config, Deserialize, Dialer, Error, Listener, Packet, Result, Serialize, Stream,
+            TcpDialer, TcpDialerExt, TcpTransport, Transport};
 
-struct ConnectionHandler<'a, S>
-    where S: Serve
+struct ConnectionHandler<'a, S, St>
+    where S: Serve,
+          St: Stream,
 {
-    read_stream: BufReader<TcpStream>,
-    write_stream: BufWriter<TcpStream>,
+    read_stream: BufReader<St>,
+    write_stream: BufWriter<St>,
     server: S,
     shutdown: &'a AtomicBool,
 }
 
-impl<'a, S> ConnectionHandler<'a, S>
-    where S: Serve
+impl<'a, S, St> ConnectionHandler<'a, S, St>
+    where S: Serve,
+          St: Stream,
 {
     fn handle_conn<'b>(&'b mut self, scope: &Scope<'b>) -> Result<()> {
         let ConnectionHandler {
@@ -83,7 +86,7 @@ impl<'a, S> ConnectionHandler<'a, S>
         }
     }
 
-    fn write(rx: Receiver<Packet<<S as Serve>::Reply>>, stream: &mut BufWriter<TcpStream>) {
+    fn write(rx: Receiver<Packet<<S as Serve>::Reply>>, stream: &mut BufWriter<St>) {
         loop {
             match rx.recv() {
                 Err(e) => {
@@ -101,21 +104,30 @@ impl<'a, S> ConnectionHandler<'a, S>
 }
 
 /// Provides methods for blocking until the server completes,
-pub struct ServeHandle {
+pub struct ServeHandle<D>
+    where D: Dialer
+{
     tx: Sender<()>,
     join_handle: JoinHandle<()>,
-    addr: SocketAddr,
+    dialer: D,
 }
 
-impl ServeHandle {
+impl<D> ServeHandle<D>
+    where D: Dialer
+{
     /// Block until the server completes
     pub fn wait(self) {
         self.join_handle.join().expect(pos!());
     }
 
-    /// Returns the address the server is bound to
-    pub fn local_addr(&self) -> &SocketAddr {
-        &self.addr
+    /// Returns the dialer to the server.
+    pub fn dialer(&self) -> &D {
+        &self.dialer
+    }
+
+    /// Returns the socket being listened on when the dialer is a `TcpDialer`.
+    pub fn local_addr(&self) -> &D::Addr where D: TcpDialerExt {
+        self.dialer().addr()
     }
 
     /// Shutdown the server. Gracefully shuts down the serve thread but currently does not
@@ -123,7 +135,7 @@ impl ServeHandle {
     pub fn shutdown(self) {
         info!("ServeHandle: attempting to shut down the server.");
         self.tx.send(()).expect(pos!());
-        if let Ok(_) = TcpStream::connect(self.addr) {
+        if let Ok(_) = self.dialer.dial() {
             self.join_handle.join().expect(pos!());
         } else {
             warn!("ServeHandle: best effort shutdown of serve thread failed");
@@ -131,15 +143,15 @@ impl ServeHandle {
     }
 }
 
-struct Server<'a, S: 'a> {
+struct Server<'a, S: 'a, L: Listener> {
     server: &'a S,
-    listener: TcpListener,
+    listener: L,
     read_timeout: Option<Duration>,
     die_rx: Receiver<()>,
     shutdown: &'a AtomicBool,
 }
 
-impl<'a, S: 'a> Server<'a, S>
+impl<'a, S: 'a, L: Listener> Server<'a, S, L>
     where S: Serve + 'static
 {
     fn serve<'b>(self, scope: &Scope<'b>)
@@ -194,7 +206,7 @@ impl<'a, S: 'a> Server<'a, S>
     }
 }
 
-impl<'a, S> Drop for Server<'a, S> {
+impl<'a, S, L: Listener> Drop for Server<'a, S, L> {
     fn drop(&mut self) {
         debug!("Shutting down connection handlers.");
         self.shutdown.store(true, Ordering::SeqCst);
@@ -212,29 +224,30 @@ pub trait Serve: Send + Sync + Sized {
     fn serve(&self, request: Self::Request) -> Self::Reply;
 
     /// spawn
-    fn spawn<A>(self, addr: A) -> io::Result<ServeHandle>
+    fn spawn<A: fmt::Debug>(self, addr: A) -> io::Result<ServeHandle<TcpDialer<SocketAddr>>>
         where A: ToSocketAddrs,
               Self: 'static,
     {
-        self.spawn_with_config(addr, Config::default())
+        self.spawn_with_config(TcpTransport(addr), Config::default())
     }
 
     /// spawn
-    fn spawn_with_config<A>(self, addr: A, config: Config) -> io::Result<ServeHandle>
-        where A: ToSocketAddrs,
-              Self: 'static,
+    fn spawn_with_config<T: Transport>(self, transport: T, config: Config)
+        -> io::Result<ServeHandle<<T::Listener as Listener>::Dialer>>
+        where Self: 'static,
     {
-        let listener = try!(TcpListener::bind(&addr));
-        let addr = try!(listener.local_addr());
-        info!("spawn_with_config: spinning up server on {:?}", addr);
+        let listener = try!(transport.bind());
+        let dialer = try!(listener.dialer());
+        info!("spawn_with_config: spinning up server.");
         let (die_tx, die_rx) = channel();
+        let timeout = config.timeout;
         let join_handle = thread::spawn(move || {
             let pool = Pool::new(100); // TODO(tjk): make this configurable, and expire idle threads
             let shutdown = AtomicBool::new(false);
             let server = Server {
                 server: &self,
                 listener: listener,
-                read_timeout: config.timeout,
+                read_timeout: timeout,
                 die_rx: die_rx,
                 shutdown: &shutdown,
             };
@@ -245,7 +258,7 @@ pub trait Serve: Send + Sync + Sized {
         Ok(ServeHandle {
             tx: die_tx,
             join_handle: join_handle,
-            addr: addr.clone(),
+            dialer: dialer,
         })
     }
 

--- a/tarpc/src/transport/mod.rs
+++ b/tarpc/src/transport/mod.rs
@@ -57,25 +57,17 @@ pub trait Stream: Read + Write + Send + Sized + 'static {
 pub trait Dialer {
     /// The type of `Stream` this can create.
     type Stream: Stream;
-    /// The type of address being connected to.
-    type Addr;
     /// Open a stream.
     fn dial(&self) -> io::Result<Self::Stream>;
-    /// Return the address being dialed.
-    fn addr(&self) -> &Self::Addr;
 }
 
-impl<P, D> Dialer for P
+impl<P, D: ?Sized> Dialer for P
     where P: ::std::ops::Deref<Target=D>,
           D: Dialer + 'static
 {
     type Stream = D::Stream;
-    type Addr = D::Addr;
     fn dial(&self) -> io::Result<Self::Stream> {
         (**self).dial()
-    }
-    fn addr(&self) -> &Self::Addr {
-        (**self).addr()
     }
 }
 

--- a/tarpc/src/transport/mod.rs
+++ b/tarpc/src/transport/mod.rs
@@ -29,9 +29,9 @@ pub trait Listener: Send + 'static {
 
 /// A cloneable Reader/Writer.
 pub trait Stream: Read + Write + Send + Sized + 'static {
-    /// Creates a new independently owned handle to the underlying socket.
+    /// Creates a new independently owned handle to the Stream.
     ///
-    /// The returned TcpStream should reference the same stream that this
+    /// The returned Stream should reference the same stream that this
     /// object references. Both handles should read and write the same
     /// stream of data, and options set on one stream should be propagated
     /// to the other stream.

--- a/tarpc/src/transport/mod.rs
+++ b/tarpc/src/transport/mod.rs
@@ -29,13 +29,27 @@ pub trait Listener: Send + 'static {
 
 /// A cloneable Reader/Writer.
 pub trait Stream: Read + Write + Send + Sized + 'static {
-    /// Clone that can fail.
+    /// Creates a new independently owned handle to the underlying socket.
+    ///
+    /// The returned TcpStream should reference the same stream that this
+    /// object references. Both handles should read and write the same
+    /// stream of data, and options set on one stream should be propagated
+    /// to the other stream.
     fn try_clone(&self) -> io::Result<Self>;
     /// Sets a read timeout.
+    ///
+    /// If the value specified is `None`, then read calls will block indefinitely.
+    /// It is an error to pass the zero `Duration` to this method.
     fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()>;
     /// Sets a write timeout.
+    ///
+    /// If the value specified is `None`, then write calls will block indefinitely.
+    /// It is an error to pass the zero `Duration` to this method.
     fn set_write_timeout(&self, dur: Option<Duration>) -> io::Result<()>;
     /// Shuts down both ends of the stream.
+    ///
+    /// Implementations should cause all pending and future I/O on the specified
+    /// portions to return immediately with an appropriate value.
     fn shutdown(&self) -> io::Result<()>;
 }
 

--- a/tarpc/src/transport/mod.rs
+++ b/tarpc/src/transport/mod.rs
@@ -51,6 +51,20 @@ pub trait Dialer {
     fn addr(&self) -> &Self::Addr;
 }
 
+impl<P, D> Dialer for P
+    where P: ::std::ops::Deref<Target=D>,
+          D: Dialer + 'static
+{
+    type Stream = D::Stream;
+    type Addr = D::Addr;
+    fn dial(&self) -> io::Result<Self::Stream> {
+        (**self).dial()
+    }
+    fn addr(&self) -> &Self::Addr {
+        (**self).addr()
+    }
+}
+
 /// Iterates over incoming connections.
 pub struct Incoming<'a, L: Listener + ?Sized + 'a> {
     listener: &'a L,

--- a/tarpc/src/transport/mod.rs
+++ b/tarpc/src/transport/mod.rs
@@ -1,0 +1,70 @@
+use std::io::{self, Read, Write};
+use std::time::Duration;
+
+/// A factory for creating a listener on a given address.
+pub trait Transport {
+    /// The type of listener that binds to the given address.
+    type Listener: Listener;
+    /// Return a listener on the given address, and a dialer to that address.
+    fn bind(&self) -> io::Result<Self::Listener>;
+}
+
+/// Accepts incoming connections from dialers.
+pub trait Listener: Send + 'static {
+    /// The type of address being listened on.
+    type Dialer: Dialer;
+    /// The type of stream this listener accepts.
+    type Stream: Stream;
+    /// Accept an incoming stream.
+    fn accept(&self) -> io::Result<Self::Stream>;
+    /// Returns the local address being listened on.
+    fn dialer(&self) -> io::Result<Self::Dialer>;
+    /// Iterate over incoming connections.
+    fn incoming(&self) -> Incoming<Self> {
+        Incoming {
+            listener: self,
+        }
+    }
+}
+
+/// A cloneable Reader/Writer.
+pub trait Stream: Read + Write + Send + Sized + 'static {
+    /// Clone that can fail.
+    fn try_clone(&self) -> io::Result<Self>;
+    /// Sets a read timeout.
+    fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()>;
+    /// Sets a write timeout.
+    fn set_write_timeout(&self, dur: Option<Duration>) -> io::Result<()>;
+    /// Shuts down both ends of the stream.
+    fn shutdown(&self) -> io::Result<()>;
+}
+
+/// A `Stream` factory.
+pub trait Dialer {
+    /// The type of `Stream` this can create.
+    type Stream: Stream;
+    /// The type of address being connected to.
+    type Addr;
+    /// Open a stream.
+    fn dial(&self) -> io::Result<Self::Stream>;
+    /// Return the address being dialed.
+    fn addr(&self) -> &Self::Addr;
+}
+
+/// Iterates over incoming connections.
+pub struct Incoming<'a, L: Listener + ?Sized + 'a> {
+    listener: &'a L,
+}
+
+impl<'a, L: Listener> Iterator for Incoming<'a, L> {
+    type Item = io::Result<L::Stream>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Some(self.listener.accept())
+    }
+}
+
+/// Provides a TCP transport.
+pub mod tcp;
+/// Provides a unix socket transport.
+pub mod unix;

--- a/tarpc/src/transport/mod.rs
+++ b/tarpc/src/transport/mod.rs
@@ -2,6 +2,8 @@ use std::io::{self, Read, Write};
 use std::time::Duration;
 
 /// A factory for creating a listener on a given address.
+/// For TCP, an address might be an IPv4 address; for Unix sockets, it
+/// is just a file name.
 pub trait Transport {
     /// The type of listener that binds to the given address.
     type Listener: Listener;

--- a/tarpc/src/transport/mod.rs
+++ b/tarpc/src/transport/mod.rs
@@ -21,9 +21,7 @@ pub trait Listener: Send + 'static {
     fn dialer(&self) -> io::Result<Self::Dialer>;
     /// Iterate over incoming connections.
     fn incoming(&self) -> Incoming<Self> {
-        Incoming {
-            listener: self,
-        }
+        Incoming { listener: self }
     }
 }
 
@@ -62,7 +60,7 @@ pub trait Dialer {
 }
 
 impl<P, D: ?Sized> Dialer for P
-    where P: ::std::ops::Deref<Target=D>,
+    where P: ::std::ops::Deref<Target = D>,
           D: Dialer + 'static
 {
     type Stream = D::Stream;

--- a/tarpc/src/transport/mod.rs
+++ b/tarpc/src/transport/mod.rs
@@ -66,6 +66,7 @@ impl<P, D: ?Sized> Dialer for P
           D: Dialer + 'static
 {
     type Stream = D::Stream;
+
     fn dial(&self) -> io::Result<Self::Stream> {
         (**self).dial()
     }

--- a/tarpc/src/transport/tcp.rs
+++ b/tarpc/src/transport/tcp.rs
@@ -45,8 +45,7 @@ impl super::Stream for TcpStream {
 }
 
 /// Connects to a socket address.
-pub struct TcpDialer<A = SocketAddr>(pub A)
-    where A: ToSocketAddrs;
+pub struct TcpDialer<A = SocketAddr>(pub A) where A: ToSocketAddrs;
 impl<A> super::Dialer for TcpDialer<A>
     where A: ToSocketAddrs
 {
@@ -55,8 +54,7 @@ impl<A> super::Dialer for TcpDialer<A>
         TcpStream::connect(&self.0)
     }
 }
-impl super::Dialer for str
-{
+impl super::Dialer for str {
     type Stream = TcpStream;
     fn dial(&self) -> io::Result<TcpStream> {
         TcpStream::connect(self)

--- a/tarpc/src/transport/tcp.rs
+++ b/tarpc/src/transport/tcp.rs
@@ -1,0 +1,52 @@
+use std::io;
+use std::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
+use std::time::Duration;
+
+/// A transport for TCP.
+pub struct TcpTransport<A: ToSocketAddrs>(pub A);
+impl<A: ToSocketAddrs> super::Transport for TcpTransport<A> {
+    type Listener = TcpListener;
+    fn bind(&self) -> io::Result<TcpListener> {
+        TcpListener::bind(&self.0)
+    }
+}
+
+impl super::Listener for TcpListener {
+    type Dialer = TcpDialer<SocketAddr>;
+    type Stream = TcpStream;
+    fn accept(&self) -> io::Result<TcpStream> {
+        self.accept().map(|(stream, _)| stream)
+    }
+    fn dialer(&self) -> io::Result<TcpDialer<SocketAddr>> {
+        self.local_addr().map(|addr| TcpDialer(addr))
+    }
+}
+
+impl super::Stream for TcpStream {
+    fn try_clone(&self) -> io::Result<Self> {
+        self.try_clone()
+    }
+    fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
+        self.set_read_timeout(dur)
+    }
+    fn set_write_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
+        self.set_write_timeout(dur)
+    }
+    fn shutdown(&self) -> io::Result<()> {
+        self.shutdown(::std::net::Shutdown::Both)
+    }
+}
+
+/// Connects to a socket address.
+pub struct TcpDialer<A = SocketAddr>(pub A)
+    where A: ToSocketAddrs;
+impl<A: ToSocketAddrs> super::Dialer for TcpDialer<A> {
+    type Stream = TcpStream;
+    type Addr = A;
+    fn dial(&self) -> io::Result<TcpStream> {
+        TcpStream::connect(&self.0)
+    }
+    fn addr(&self) -> &A {
+        &self.0
+    }
+}

--- a/tarpc/src/transport/tcp.rs
+++ b/tarpc/src/transport/tcp.rs
@@ -47,6 +47,7 @@ impl super::Stream for TcpStream {
 
 /// Connects to a socket address.
 pub struct TcpDialer<A = SocketAddr>(pub A) where A: ToSocketAddrs;
+
 impl<A> super::Dialer for TcpDialer<A>
     where A: ToSocketAddrs
 {

--- a/tarpc/src/transport/tcp.rs
+++ b/tarpc/src/transport/tcp.rs
@@ -7,6 +7,7 @@ pub struct TcpTransport<A: ToSocketAddrs>(pub A);
 
 impl<A: ToSocketAddrs> super::Transport for TcpTransport<A> {
     type Listener = TcpListener;
+
     fn bind(&self) -> io::Result<TcpListener> {
         TcpListener::bind(&self.0)
     }
@@ -14,6 +15,7 @@ impl<A: ToSocketAddrs> super::Transport for TcpTransport<A> {
 
 impl<A: ToSocketAddrs> super::Transport for A {
     type Listener = TcpListener;
+
     fn bind(&self) -> io::Result<TcpListener> {
         TcpListener::bind(self)
     }
@@ -21,10 +23,13 @@ impl<A: ToSocketAddrs> super::Transport for A {
 
 impl super::Listener for TcpListener {
     type Dialer = TcpDialer<SocketAddr>;
+
     type Stream = TcpStream;
+
     fn accept(&self) -> io::Result<TcpStream> {
         self.accept().map(|(stream, _)| stream)
     }
+
     fn dialer(&self) -> io::Result<TcpDialer<SocketAddr>> {
         self.local_addr().map(|addr| TcpDialer(addr))
     }
@@ -34,12 +39,15 @@ impl super::Stream for TcpStream {
     fn try_clone(&self) -> io::Result<Self> {
         self.try_clone()
     }
+
     fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
         self.set_read_timeout(dur)
     }
+
     fn set_write_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
         self.set_write_timeout(dur)
     }
+
     fn shutdown(&self) -> io::Result<()> {
         self.shutdown(::std::net::Shutdown::Both)
     }
@@ -52,12 +60,15 @@ impl<A> super::Dialer for TcpDialer<A>
     where A: ToSocketAddrs
 {
     type Stream = TcpStream;
+
     fn dial(&self) -> io::Result<TcpStream> {
         TcpStream::connect(&self.0)
     }
 }
+
 impl super::Dialer for str {
     type Stream = TcpStream;
+
     fn dial(&self) -> io::Result<TcpStream> {
         TcpStream::connect(self)
     }

--- a/tarpc/src/transport/tcp.rs
+++ b/tarpc/src/transport/tcp.rs
@@ -11,6 +11,13 @@ impl<A: ToSocketAddrs> super::Transport for TcpTransport<A> {
     }
 }
 
+impl<A: ToSocketAddrs> super::Transport for A {
+    type Listener = TcpListener;
+    fn bind(&self) -> io::Result<TcpListener> {
+        TcpListener::bind(self)
+    }
+}
+
 impl super::Listener for TcpListener {
     type Dialer = TcpDialer<SocketAddr>;
     type Stream = TcpStream;
@@ -40,13 +47,18 @@ impl super::Stream for TcpStream {
 /// Connects to a socket address.
 pub struct TcpDialer<A = SocketAddr>(pub A)
     where A: ToSocketAddrs;
-impl<A: ToSocketAddrs> super::Dialer for TcpDialer<A> {
+impl<A> super::Dialer for TcpDialer<A>
+    where A: ToSocketAddrs
+{
     type Stream = TcpStream;
-    type Addr = A;
     fn dial(&self) -> io::Result<TcpStream> {
         TcpStream::connect(&self.0)
     }
-    fn addr(&self) -> &A {
-        &self.0
+}
+impl super::Dialer for str
+{
+    type Stream = TcpStream;
+    fn dial(&self) -> io::Result<TcpStream> {
+        TcpStream::connect(self)
     }
 }

--- a/tarpc/src/transport/tcp.rs
+++ b/tarpc/src/transport/tcp.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 /// A transport for TCP.
 pub struct TcpTransport<A: ToSocketAddrs>(pub A);
+
 impl<A: ToSocketAddrs> super::Transport for TcpTransport<A> {
     type Listener = TcpListener;
     fn bind(&self) -> io::Result<TcpListener> {

--- a/tarpc/src/transport/unix.rs
+++ b/tarpc/src/transport/unix.rs
@@ -1,0 +1,60 @@
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use unix_socket::{UnixListener, UnixStream};
+
+/// A transport for unix sockets.
+pub struct UnixTransport<P>(pub P)
+    where P: AsRef<Path>;
+
+impl<P> super::Transport for UnixTransport<P>
+    where P: AsRef<Path>
+{
+    type Listener = UnixListener;
+    fn bind(&self) -> io::Result<UnixListener> {
+        UnixListener::bind(&self.0)
+    }
+}
+
+/// Connects to a unix socket address.
+pub struct UnixDialer<P>(pub P)
+    where P: AsRef<Path>;
+
+impl<P> super::Dialer for UnixDialer<P>
+    where P: AsRef<Path>
+{
+    type Stream = UnixStream;
+    type Addr = P;
+    fn dial(&self) -> io::Result<UnixStream> {
+        UnixStream::connect(&self.0)
+    }
+    fn addr(&self) -> &P {
+        &self.0
+    }
+}
+
+impl super::Listener for UnixListener {
+    type Stream = UnixStream;
+    type Dialer = UnixDialer<PathBuf>;
+    fn accept(&self) -> io::Result<UnixStream> {
+        self.accept().map(|(stream, _)| stream)
+    }
+    fn dialer(&self) -> io::Result<UnixDialer<PathBuf>> {
+        self.local_addr().map(|addr| UnixDialer(addr.as_pathname().unwrap().to_owned()))
+    }
+}
+
+impl super::Stream for UnixStream {
+    fn try_clone(&self) -> io::Result<Self> {
+        self.try_clone()
+    }
+    fn set_read_timeout(&self, timeout: Option<Duration>) -> io::Result<()> {
+        self.set_read_timeout(timeout)
+    }
+    fn set_write_timeout(&self, timeout: Option<Duration>) -> io::Result<()> {
+        self.set_write_timeout(timeout)
+    }
+    fn shutdown(&self) -> io::Result<()> {
+        self.shutdown(::std::net::Shutdown::Both)
+    }
+}

--- a/tarpc/src/transport/unix.rs
+++ b/tarpc/src/transport/unix.rs
@@ -4,8 +4,7 @@ use std::time::Duration;
 use unix_socket::{UnixListener, UnixStream};
 
 /// A transport for unix sockets.
-pub struct UnixTransport<P>(pub P)
-    where P: AsRef<Path>;
+pub struct UnixTransport<P>(pub P) where P: AsRef<Path>;
 
 impl<P> super::Transport for UnixTransport<P>
     where P: AsRef<Path>
@@ -17,8 +16,7 @@ impl<P> super::Transport for UnixTransport<P>
 }
 
 /// Connects to a unix socket address.
-pub struct UnixDialer<P>(pub P)
-    where P: AsRef<Path>;
+pub struct UnixDialer<P>(pub P) where P: AsRef<Path>;
 
 impl<P> super::Dialer for UnixDialer<P>
     where P: AsRef<Path>

--- a/tarpc/src/transport/unix.rs
+++ b/tarpc/src/transport/unix.rs
@@ -24,12 +24,8 @@ impl<P> super::Dialer for UnixDialer<P>
     where P: AsRef<Path>
 {
     type Stream = UnixStream;
-    type Addr = P;
     fn dial(&self) -> io::Result<UnixStream> {
         UnixStream::connect(&self.0)
-    }
-    fn addr(&self) -> &P {
-        &self.0
     }
 }
 

--- a/tarpc/src/transport/unix.rs
+++ b/tarpc/src/transport/unix.rs
@@ -34,10 +34,14 @@ impl super::Listener for UnixListener {
         self.accept().map(|(stream, _)| stream)
     }
     fn dialer(&self) -> io::Result<UnixDialer<PathBuf>> {
-        self.local_addr().and_then(|addr| match addr.as_pathname() {
-            Some(path) => Ok(UnixDialer(path.to_owned())),
-            None => Err(io::Error::new(io::ErrorKind::AddrNotAvailable,
-                                       "Couldn't get a path to bound unix socket")),
+        self.local_addr().and_then(|addr| {
+            match addr.as_pathname() {
+                Some(path) => Ok(UnixDialer(path.to_owned())),
+                None => {
+                    Err(io::Error::new(io::ErrorKind::AddrNotAvailable,
+                                       "Couldn't get a path to bound unix socket"))
+                }
+            }
         })
     }
 }

--- a/tarpc/src/transport/unix.rs
+++ b/tarpc/src/transport/unix.rs
@@ -10,6 +10,7 @@ impl<P> super::Transport for UnixTransport<P>
     where P: AsRef<Path>
 {
     type Listener = UnixListener;
+
     fn bind(&self) -> io::Result<UnixListener> {
         UnixListener::bind(&self.0)
     }
@@ -22,6 +23,7 @@ impl<P> super::Dialer for UnixDialer<P>
     where P: AsRef<Path>
 {
     type Stream = UnixStream;
+
     fn dial(&self) -> io::Result<UnixStream> {
         UnixStream::connect(&self.0)
     }
@@ -29,10 +31,13 @@ impl<P> super::Dialer for UnixDialer<P>
 
 impl super::Listener for UnixListener {
     type Stream = UnixStream;
+
     type Dialer = UnixDialer<PathBuf>;
+
     fn accept(&self) -> io::Result<UnixStream> {
         self.accept().map(|(stream, _)| stream)
     }
+
     fn dialer(&self) -> io::Result<UnixDialer<PathBuf>> {
         self.local_addr().and_then(|addr| {
             match addr.as_pathname() {
@@ -50,12 +55,15 @@ impl super::Stream for UnixStream {
     fn try_clone(&self) -> io::Result<Self> {
         self.try_clone()
     }
+
     fn set_read_timeout(&self, timeout: Option<Duration>) -> io::Result<()> {
         self.set_read_timeout(timeout)
     }
+
     fn set_write_timeout(&self, timeout: Option<Duration>) -> io::Result<()> {
         self.set_write_timeout(timeout)
     }
+
     fn shutdown(&self) -> io::Result<()> {
         self.shutdown(::std::net::Shutdown::Both)
     }

--- a/tarpc/src/transport/unix.rs
+++ b/tarpc/src/transport/unix.rs
@@ -34,7 +34,11 @@ impl super::Listener for UnixListener {
         self.accept().map(|(stream, _)| stream)
     }
     fn dialer(&self) -> io::Result<UnixDialer<PathBuf>> {
-        self.local_addr().map(|addr| UnixDialer(addr.as_pathname().unwrap().to_owned()))
+        self.local_addr().and_then(|addr| match addr.as_pathname() {
+            Some(path) => Ok(UnixDialer(path.to_owned())),
+            None => Err(io::Error::new(io::ErrorKind::AddrNotAvailable,
+                                       "Couldn't get a path to bound unix socket")),
+        })
     }
 }
 

--- a/tarpc_examples/src/lib.rs
+++ b/tarpc_examples/src/lib.rs
@@ -41,8 +41,9 @@ mod benchmark {
             Arc::new(Mutex::new(handle))
         };
         static ref CLIENT: Arc<Mutex<AsyncClient>> = {
-            let addr = HANDLE.lock().unwrap().local_addr().clone();
-            let client = AsyncClient::new(addr).unwrap();
+            let lock = HANDLE.lock().unwrap();
+            let dialer = lock.dialer();
+            let client = AsyncClient::new(dialer).unwrap();
             Arc::new(Mutex::new(client))
         };
     }


### PR DESCRIPTION
Quite a bit of machinery added:
 * Listener trait
 * Dialer trait
 * Stream trait
 * Transport trait

I made a lot of types default to `Tcp*` for:
 1. Convenience
 2. Backwards compatibility (though it's still a breaking change in some respects)

~~Before merging this, we should `impl` the traits for [unix_socket](http://rust-lang-nursery.github.io/unix-socket/doc/v0.5.0/unix_socket/) to make sure the trait is compatible.~~
I've now `impl`ed `Transport` for  Unix sockets:

* `Server.spawn(UnixTransport(path))`
* `Client::new(UnixDialer(path))`

**This is a breaking change** but only for code that used `ToSocketAddrs` args other than `&str`. Code using `&str` to specify address will still work.
To update code:
`Server.spawn(socket_addr)` => `Server.spawn(TcpTransport(socket_addr))`

### Bikeshed
As I played around with unix sockets, I grew frustrated with the second-class nature of them WRT tarpc. Specifically, having to use `spawn_with_config` just because the transport changed, even though I was using default `Config` settings, was annoying. In light of that, I propose making `spawn` take a `Transport`, and just go ahead and `impl<A: ToSocketAddrs> Transport for A { ... }` such that it creates a tcp transport. Even though other transports use sockets, I think it's reasonable to have a sane default here for the sake of ergonomics.

If you think that's reasonable, I'll add that to this PR, as well.

*Update: the above was implemented as well, but due to coherence, I can only do `impl<'a> Transport for &'a str`. Specialization might allow `Transport` impls for all `ToSocketAddrs` types, but maybe not.*

Fixes #16 