### PR TITLE
Fix formatting pre-commit check

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -92,11 +92,9 @@ FMTRESULT=0
 for file in $(git diff --name-only --cached);
 do
 	if [ ${file: -3} == ".rs" ]; then
-		HASH=$(shasum < $file)
-		NEW_HASH=$(rustfmt --skip-children --write-mode=display < $file | shasum)
-        echo $HASH
-        echo $NEW_HASH
-		if [ "${HASH}" != "${NEW_HASH}" ]; then
+        diff=$(rustfmt --skip-children --write-mode=diff $file)
+        result=$(echo $diff | grep --quiet "^Diff at line")
+        if $result; then
 			FMTRESULT=1
 		fi
 	fi
@@ -107,6 +105,7 @@ if [ "${TARPC_SKIP_RUSTFMT}" == 1 ]; then
 elif [ ${FMTRESULT} != 0 ]; then
 	FAILED=1
 	printf "${FAILURE}\n"
+    echo "$diff" | sed '/Using rustfmt.*$/d'
 else
 	printf "${SUCCESS}\n"
 fi

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -93,7 +93,7 @@ for file in $(git diff --name-only --cached);
 do
 	if [ ${file: -3} == ".rs" ]; then
 		HASH=$(shasum < $file)
-		NEW_HASH=$(rustfmt --write-mode=display < $file | shasum)
+		NEW_HASH=$(rustfmt --skip-children --write-mode=display < $file | shasum)
         echo $HASH
         echo $NEW_HASH
 		if [ "${HASH}" != "${NEW_HASH}" ]; then

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -92,8 +92,10 @@ FMTRESULT=0
 for file in $(git diff --name-only --cached);
 do
 	if [ ${file: -3} == ".rs" ]; then
-		HASH=$(shasum $file)
-		NEW_HASH=$(rustfmt --write-mode=display $file | shasum)
+		HASH=$(shasum < $file)
+		NEW_HASH=$(rustfmt --write-mode=display < $file | shasum)
+        echo $HASH
+        echo $NEW_HASH
 		if [ "${HASH}" != "${NEW_HASH}" ]; then
 			FMTRESULT=1
 		fi


### PR DESCRIPTION
The hashing didn't work, so I replaced it with `write-mode=diff`.

I also print the diff if the formatting check fails. Example:

```
$ git commit -am "Test commit"
[PRECOMMIT] Checking that all filenames are ascii ... ok
[PRECOMMIT] Checking for bad whitespace ... ok
[PRECOMMIT] Checking for rustfmt ... ok
[PRECOMMIT] Checking for shasum ... ok
[PRECOMMIT] Checking formatting ... FAILED
Diff of tarpc/src/protocol/mod.rs:


Diff at line 19:
 pub use self::client::{Client, Future};⏎
 pub use self::server::{Serve, ServeHandle};⏎
 ⏎
-pub mod test_fmt { }⏎
+pub mod test_fmt {}⏎
 ⏎
 /// Client errors that can occur during rpc calls⏎
 #[derive(Debug, Clone)]⏎
```