### PR TITLE
Upgrade serde to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ readme = "README.md"
 description = "An RPC framework for Rust with a focus on ease of use."
 
 [dependencies]
-bincode = "0.6"
 byteorder = "0.5"
+bincode = "1.0.0-alpha"
 cfg-if = "0.1.0"
 bytes = "0.3"
 futures = "0.1.7"
@@ -20,8 +20,8 @@ lazy_static = "0.2"
 log = "0.3"
 native-tls = { version = "0.1.1", optional = true }
 scoped-pool = "1.0"
-serde = "0.8"
-serde_derive = "0.8"
+serde = "0.9"
+serde_derive = "0.9"
 tarpc-plugins = { path = "src/plugins" }
 take = "0.1"
 tokio-service = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ readme = "README.md"
 description = "An RPC framework for Rust with a focus on ease of use."
 
 [dependencies]
-byteorder = "0.5"
 bincode = "1.0.0-alpha"
+byteorder = "1.0"
 cfg-if = "0.1.0"
 bytes = "0.3"
 futures = "0.1.7"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -15,8 +15,8 @@ macro_rules! impl_serialize {
     ($impler:ident, { $($lifetime:tt)* }, $(@($name:ident $n:expr))* -- #($n_:expr) ) => {
         as_item! {
             impl$($lifetime)* $crate::serde::Serialize for $impler$($lifetime)* {
-                fn serialize<S>(&self, impl_serialize_serializer__: &mut S)
-                    -> ::std::result::Result<(), S::Error>
+                fn serialize<S>(&self, impl_serialize_serializer__: S)
+                    -> ::std::result::Result<S::Ok, S::Error>
                     where S: $crate::serde::Serializer
                 {
                     match *self {
@@ -59,7 +59,7 @@ macro_rules! impl_deserialize {
         impl $crate::serde::Deserialize for $impler {
             #[allow(non_camel_case_types)]
             fn deserialize<impl_deserialize_D__>(
-                impl_deserialize_deserializer__: &mut impl_deserialize_D__)
+                impl_deserialize_deserializer__: impl_deserialize_D__)
                 -> ::std::result::Result<$impler, impl_deserialize_D__::Error>
                 where impl_deserialize_D__: $crate::serde::Deserializer
             {
@@ -69,7 +69,7 @@ macro_rules! impl_deserialize {
                 }
 
                 impl $crate::serde::Deserialize for impl_deserialize_Field__ {
-                    fn deserialize<D>(impl_deserialize_deserializer__: &mut D)
+                    fn deserialize<D>(impl_deserialize_deserializer__: D)
                         -> ::std::result::Result<impl_deserialize_Field__, D::Error>
                         where D: $crate::serde::Deserializer
                     {
@@ -77,7 +77,11 @@ macro_rules! impl_deserialize {
                         impl $crate::serde::de::Visitor for impl_deserialize_FieldVisitor__ {
                             type Value = impl_deserialize_Field__;
 
-                            fn visit_usize<E>(&mut self, impl_deserialize_value__: usize)
+                            fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                                formatter.write_str("an unsigned integer")
+                            }
+
+                            fn visit_u64<E>(self, impl_deserialize_value__: u64)
                                 -> ::std::result::Result<impl_deserialize_Field__, E>
                                 where E: $crate::serde::de::Error,
                             {
@@ -100,18 +104,23 @@ macro_rules! impl_deserialize {
                 }
 
                 struct Visitor;
-                impl $crate::serde::de::EnumVisitor for Visitor {
+                impl $crate::serde::de::Visitor for Visitor {
                     type Value = $impler;
 
-                    fn visit<V>(&mut self, mut tarpc_enum_visitor__: V)
-                        -> ::std::result::Result<$impler, V::Error>
-                        where V: $crate::serde::de::VariantVisitor
+                    fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                        formatter.write_str("an enum variant")
+                    }
+
+                    fn visit_enum<V>(self, tarpc_enum_visitor__: V)
+                        -> ::std::result::Result<Self::Value, V::Error>
+                        where V: $crate::serde::de::EnumVisitor
                     {
+                        use $crate::serde::de::VariantVisitor;
                         match tarpc_enum_visitor__.visit_variant()? {
                             $(
-                                impl_deserialize_Field__::$name => {
+                                (impl_deserialize_Field__::$name, variant) => {
                                     ::std::result::Result::Ok(
-                                        $impler::$name(tarpc_enum_visitor__.visit_newtype()?))
+                                        $impler::$name(variant.visit_newtype()?))
                                 }
                             ),*
                         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -52,7 +52,7 @@ impl Stream for Never {
 }
 
 impl Serialize for Never {
-    fn serialize<S>(&self, _: &mut S) -> Result<(), S::Error>
+    fn serialize<S>(&self, _: S) -> Result<S::Ok, S::Error>
         where S: Serializer
     {
         self.0
@@ -61,7 +61,7 @@ impl Serialize for Never {
 
 // Please don't try to deserialize this. :(
 impl Deserialize for Never {
-    fn deserialize<D>(_: &mut D) -> Result<Self, D::Error>
+    fn deserialize<D>(_: D) -> Result<Self, D::Error>
         where D: Deserializer
     {
         panic!("Never cannot be instantiated!");


### PR DESCRIPTION
I've made changes to support serde 0.9. Serde 0.9 is not compatible with serde 0.8 so this is a breaking change.

I also upgraded byteorder to 1.0 (no changes were needed for that).