### PR TITLE
Remove the `Send` bound from `FutureService`

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ extern crate tokio_core;
 
 use futures::Future;
 use tarpc::{client, server};
-use tarpc::client::future::Connect;
+use tarpc::client::future::ClientExt;
 use tarpc::util::{FirstSocketAddr, Never};
 use tokio_core::reactor;
 
@@ -174,7 +174,7 @@ extern crate tokio_core;
 
 use futures::Future;
 use tarpc::{client, server};
-use tarpc::client::future::Connect;
+use tarpc::client::future::ClientExt;
 use tarpc::util::{FirstSocketAddr, Never};
 use tokio_core::reactor;
 use tarpc::native_tls::{Pkcs12, TlsAcceptor};

--- a/README.md
+++ b/README.md
@@ -50,10 +50,12 @@ tarpc-plugins = { git = "https://github.com/google/tarpc" }
 extern crate futures;
 #[macro_use]
 extern crate tarpc;
+extern crate tokio_core;
 
 use tarpc::{client, server};
 use tarpc::client::sync::Connect;
-use tarpc::util::Never;
+use tarpc::util::{FirstSocketAddr, Never};
+use tokio_core::reactor;
 
 service! {
     rpc hello(name: String) -> String;
@@ -69,9 +71,11 @@ impl SyncService for HelloServer {
 }
 
 fn main() {
-    let addr = "localhost:10000";
-    HelloServer.listen(addr, server::Options::default()).unwrap();
-    let client = SyncClient::connect(addr, client::Options::default()).unwrap();
+    let reactor = reactor::Core::new().unwrap();
+    let addr = HelloServer.listen("localhost:0".first_socket_addr(),
+                                  server::Options::from(reactor.handle()))
+                          .unwrap();
+    let mut client = SyncClient::connect(addr, client::Options::default().core(reactor)).unwrap();
     println!("{}", client.hello("Mom".to_string()).unwrap());
 }
 ```
@@ -121,9 +125,10 @@ impl FutureService for HelloServer {
 }
 
 fn main() {
-    let addr = "localhost:10000".first_socket_addr();
     let mut core = reactor::Core::new().unwrap();
-    HelloServer.listen(addr, server::Options::default().handle(core.handle())).wait().unwrap();
+    let addr = HelloServer.listen("localhost:10000".first_socket_addr(),
+                                  server::Options::from(core.handle()))
+                          .unwrap();
     let options = client::Options::default().handle(core.handle());
     core.run(FutureClient::connect(addr, options)
             .map_err(tarpc::Error::from)
@@ -196,14 +201,16 @@ fn get_acceptor() -> TlsAcceptor {
 }
 
 fn main() {
-    let addr = "localhost:10000".first_socket_addr();
     let mut core = reactor::Core::new().unwrap();
     let acceptor = get_acceptor();
-    HelloServer.listen(addr, server::Options::default()
-                                 .handle(core.handle())
-                                 .tls(acceptor)).wait().unwrap();
-    let options = client::Options::default().handle(core.handle()
-                      .tls(client::tls::Context::new("foobar.com").unwrap()));
+    let addr = HelloServer.listen("localhost:10000".first_socket_addr(),
+                                  server::Options::default()
+                                      .handle(core.handle())
+                                      .tls(acceptor))
+                          .unwrap();
+    let options = client::Options::default()
+                                   .handle(core.handle())
+                                   .tls(client::tls::Context::new("foobar.com").unwrap()));
     core.run(FutureClient::connect(addr, options)
             .map_err(tarpc::Error::from)
             .and_then(|client| client.hello("Mom".to_string()))

--- a/README.md
+++ b/README.md
@@ -204,8 +204,7 @@ fn main() {
     let mut core = reactor::Core::new().unwrap();
     let acceptor = get_acceptor();
     let addr = HelloServer.listen("localhost:10000".first_socket_addr(),
-                                  server::Options::default()
-                                      .handle(core.handle())
+                                  server::Options::from(core.handle())
                                       .tls(acceptor))
                           .unwrap();
     let options = client::Options::default()

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ impl SyncService for HelloServer {
 fn main() {
     let reactor = reactor::Core::new().unwrap();
     let addr = HelloServer.listen("localhost:0".first_socket_addr(),
-                                  server::Options::from(reactor.handle()))
+                                  server::Options::default())
                           .unwrap();
-    let mut client = SyncClient::connect(addr, client::Options::default().core(reactor)).unwrap();
+    let mut client = SyncClient::connect(addr, client::Options::default()).unwrap();
     println!("{}", client.hello("Mom".to_string()).unwrap());
 }
 ```

--- a/benches/latency.rs
+++ b/benches/latency.rs
@@ -41,11 +41,9 @@ fn latency(bencher: &mut Bencher) {
     let _ = env_logger::init();
     let reactor = reactor::Core::new().unwrap();
     let addr = Server.listen("localhost:0".first_socket_addr(),
-                             server::Options::from(reactor.handle()))
-                     .unwrap();
-    let mut client = SyncClient::connect(addr, client::Options::default().core(reactor)).unwrap();
+                server::Options::from(reactor.handle()))
+        .unwrap();
+    let mut client = SyncClient::connect(addr, client::Options::default()).unwrap();
 
-    bencher.iter(|| {
-        client.ack().unwrap();
-    });
+    bencher.iter(|| { client.ack().unwrap(); });
 }

--- a/benches/latency.rs
+++ b/benches/latency.rs
@@ -15,7 +15,7 @@ extern crate futures;
 extern crate tokio_core;
 
 use tarpc::{client, server};
-use tarpc::client::sync::Connect;
+use tarpc::client::sync::ClientExt;
 use tarpc::util::{FirstSocketAddr, Never};
 #[cfg(test)]
 use test::Bencher;

--- a/examples/concurrency.rs
+++ b/examples/concurrency.rs
@@ -167,10 +167,9 @@ fn main() {
         .map(Result::unwrap)
         .unwrap_or(4);
 
+    let mut reactor = reactor::Core::new().unwrap();
     let addr = Server::new()
-        .listen("localhost:0".first_socket_addr(),
-                server::Options::default())
-        .wait()
+        .listen("localhost:0".first_socket_addr(), server::Options::from(reactor.handle()))
         .unwrap();
     info!("Server listening on {}.", addr);
 
@@ -190,8 +189,5 @@ fn main() {
 
     info!("Starting...");
 
-    // The driver of the main future.
-    let mut core = reactor::Core::new().unwrap();
-
-    core.run(run).unwrap();
+    reactor.run(run).unwrap();
 }

--- a/examples/concurrency.rs
+++ b/examples/concurrency.rs
@@ -25,7 +25,7 @@ use std::sync::{Arc, mpsc};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 use tarpc::{client, server};
-use tarpc::client::future::Connect;
+use tarpc::client::future::ClientExt;
 use tarpc::util::{FirstSocketAddr, Never};
 use tokio_core::reactor;
 

--- a/examples/concurrency.rs
+++ b/examples/concurrency.rs
@@ -169,7 +169,9 @@ fn main() {
 
     let mut reactor = reactor::Core::new().unwrap();
     let addr = Server::new()
-        .listen("localhost:0".first_socket_addr(), server::Options::from(reactor.handle()))
+        .listen("localhost:0".first_socket_addr(),
+                &reactor.handle(),
+                server::Options::default())
         .unwrap();
     info!("Server listening on {}.", addr);
 

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -21,8 +21,8 @@ use std::thread;
 use std::time::Duration;
 use subscriber::FutureServiceExt as SubscriberExt;
 use tarpc::{client, server};
-use tarpc::client::future::Connect as Fc;
-use tarpc::client::sync::Connect as Sc;
+use tarpc::client::future::ClientExt as Fc;
+use tarpc::client::sync::ClientExt as Sc;
 use tarpc::util::{FirstSocketAddr, Message, Never};
 use tokio_core::reactor;
 

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -59,10 +59,9 @@ impl subscriber::FutureService for Subscriber {
 
 impl Subscriber {
     fn listen(id: u32, options: server::Options) -> SocketAddr {
-        let addr = Subscriber { id: id }
+        Subscriber { id: id }
             .listen("localhost:0".first_socket_addr(), options)
-            .unwrap();
-        addr
+            .unwrap()
     }
 }
 

--- a/examples/readme_errors.rs
+++ b/examples/readme_errors.rs
@@ -16,7 +16,7 @@ extern crate tokio_core;
 use std::error::Error;
 use std::fmt;
 use tarpc::{client, server};
-use tarpc::client::sync::Connect;
+use tarpc::client::sync::ClientExt;
 use tarpc::util::FirstSocketAddr;
 use tokio_core::reactor;
 

--- a/examples/readme_errors.rs
+++ b/examples/readme_errors.rs
@@ -18,7 +18,6 @@ use std::fmt;
 use tarpc::{client, server};
 use tarpc::client::sync::ClientExt;
 use tarpc::util::FirstSocketAddr;
-use tokio_core::reactor;
 
 service! {
     rpc hello(name: String) -> String | NoNameGiven;
@@ -53,11 +52,10 @@ impl SyncService for HelloServer {
 }
 
 fn main() {
-    let reactor = reactor::Core::new().unwrap();
     let addr = HelloServer.listen("localhost:10000".first_socket_addr(),
-                                  server::Options::from(reactor.handle()))
-                          .unwrap();
-    let mut client = SyncClient::connect(addr, client::Options::default().core(reactor)).unwrap();
+                server::Options::default())
+        .unwrap();
+    let mut client = SyncClient::connect(addr, client::Options::default()).unwrap();
     println!("{}", client.hello("Mom".to_string()).unwrap());
     println!("{}", client.hello("".to_string()).unwrap_err());
 }

--- a/examples/readme_futures.rs
+++ b/examples/readme_futures.rs
@@ -13,7 +13,7 @@ extern crate tokio_core;
 
 use futures::Future;
 use tarpc::{client, server};
-use tarpc::client::future::Connect;
+use tarpc::client::future::ClientExt;
 use tarpc::util::{FirstSocketAddr, Never};
 use tokio_core::reactor;
 

--- a/examples/readme_futures.rs
+++ b/examples/readme_futures.rs
@@ -33,12 +33,13 @@ impl FutureService for HelloServer {
 }
 
 fn main() {
-    let mut core = reactor::Core::new().unwrap();
+    let mut reactor = reactor::Core::new().unwrap();
     let addr = HelloServer.listen("localhost:10000".first_socket_addr(),
-                                  server::Options::from(core.handle()))
-                          .unwrap();
-    let options = client::Options::default().handle(core.handle());
-    core.run(FutureClient::connect(addr, options)
+                &reactor.handle(),
+                server::Options::default())
+        .unwrap();
+    let options = client::Options::default().handle(reactor.handle());
+    reactor.run(FutureClient::connect(addr, options)
             .map_err(tarpc::Error::from)
             .and_then(|client| client.hello("Mom".to_string()))
             .map(|resp| println!("{}", resp)))

--- a/examples/readme_futures.rs
+++ b/examples/readme_futures.rs
@@ -33,9 +33,10 @@ impl FutureService for HelloServer {
 }
 
 fn main() {
-    let addr = "localhost:10000".first_socket_addr();
     let mut core = reactor::Core::new().unwrap();
-    HelloServer.listen(addr, server::Options::default().handle(core.handle())).wait().unwrap();
+    let addr = HelloServer.listen("localhost:10000".first_socket_addr(),
+                                  server::Options::from(core.handle()))
+                          .unwrap();
     let options = client::Options::default().handle(core.handle());
     core.run(FutureClient::connect(addr, options)
             .map_err(tarpc::Error::from)

--- a/examples/readme_sync.rs
+++ b/examples/readme_sync.rs
@@ -15,7 +15,6 @@ extern crate tokio_core;
 use tarpc::{client, server};
 use tarpc::client::sync::ClientExt;
 use tarpc::util::{FirstSocketAddr, Never};
-use tokio_core::reactor;
 
 service! {
     rpc hello(name: String) -> String;
@@ -31,10 +30,9 @@ impl SyncService for HelloServer {
 }
 
 fn main() {
-    let reactor = reactor::Core::new().unwrap();
     let addr = HelloServer.listen("localhost:0".first_socket_addr(),
-                                  server::Options::from(reactor.handle()))
-                          .unwrap();
-    let mut client = SyncClient::connect(addr, client::Options::default().core(reactor)).unwrap();
+                server::Options::default())
+        .unwrap();
+    let mut client = SyncClient::connect(addr, client::Options::default()).unwrap();
     println!("{}", client.hello("Mom".to_string()).unwrap());
 }

--- a/examples/readme_sync.rs
+++ b/examples/readme_sync.rs
@@ -13,7 +13,7 @@ extern crate tarpc;
 extern crate tokio_core;
 
 use tarpc::{client, server};
-use tarpc::client::sync::Connect;
+use tarpc::client::sync::ClientExt;
 use tarpc::util::{FirstSocketAddr, Never};
 use tokio_core::reactor;
 

--- a/examples/server_calling_server.rs
+++ b/examples/server_calling_server.rs
@@ -17,8 +17,8 @@ use double::{FutureService as DoubleFutureService, FutureServiceExt as DoubleExt
 use futures::{BoxFuture, Future};
 use std::sync::{Arc, Mutex};
 use tarpc::{client, server};
-use tarpc::client::future::Connect as Fc;
-use tarpc::client::sync::Connect as Sc;
+use tarpc::client::future::ClientExt as Fc;
+use tarpc::client::sync::ClientExt as Sc;
 use tarpc::util::{FirstSocketAddr, Message, Never};
 use tokio_core::reactor;
 

--- a/examples/throughput.rs
+++ b/examples/throughput.rs
@@ -56,9 +56,10 @@ const CHUNK_SIZE: u32 = 1 << 19;
 fn bench_tarpc(target: u64) {
     let reactor = reactor::Core::new().unwrap();
     let addr = Server.listen("localhost:0".first_socket_addr(),
-                             server::Options::from(reactor.handle()))
-                     .unwrap();
-    let mut client = SyncClient::connect(addr, client::Options::default().core(reactor)).unwrap();
+                &reactor.handle(),
+                server::Options::default())
+        .unwrap();
+    let mut client = SyncClient::connect(addr, client::Options::default()).unwrap();
     let start = time::Instant::now();
     let mut nread = 0;
     while nread < target {

--- a/examples/throughput.rs
+++ b/examples/throughput.rs
@@ -12,8 +12,8 @@ extern crate lazy_static;
 extern crate tarpc;
 extern crate env_logger;
 extern crate futures;
+extern crate tokio_core;
 
-use futures::Future;
 use std::io::{Read, Write, stdout};
 use std::net;
 use std::sync::Arc;
@@ -22,6 +22,7 @@ use std::time;
 use tarpc::{client, server};
 use tarpc::client::sync::Connect;
 use tarpc::util::{FirstSocketAddr, Never};
+use tokio_core::reactor;
 
 lazy_static! {
     static ref BUF: Arc<Vec<u8>> = Arc::new(gen_vec(CHUNK_SIZE as usize));
@@ -53,11 +54,11 @@ impl FutureService for Server {
 const CHUNK_SIZE: u32 = 1 << 19;
 
 fn bench_tarpc(target: u64) {
+    let reactor = reactor::Core::new().unwrap();
     let addr = Server.listen("localhost:0".first_socket_addr(),
-                server::Options::default())
-        .wait()
-        .unwrap();
-    let mut client = SyncClient::connect(addr, client::Options::default()).unwrap();
+                             server::Options::from(reactor.handle()))
+                     .unwrap();
+    let mut client = SyncClient::connect(addr, client::Options::default().core(reactor)).unwrap();
     let start = time::Instant::now();
     let mut nread = 0;
     while nread < target {

--- a/examples/throughput.rs
+++ b/examples/throughput.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time;
 use tarpc::{client, server};
-use tarpc::client::sync::Connect;
+use tarpc::client::sync::ClientExt;
 use tarpc::util::{FirstSocketAddr, Never};
 use tokio_core::reactor;
 

--- a/examples/two_clients.rs
+++ b/examples/two_clients.rs
@@ -18,7 +18,7 @@ extern crate tokio_core;
 use bar::FutureServiceExt as BarExt;
 use baz::FutureServiceExt as BazExt;
 use tarpc::{client, server};
-use tarpc::client::sync::Connect;
+use tarpc::client::sync::ClientExt;
 use tarpc::util::{FirstSocketAddr, Never};
 use tokio_core::reactor;
 

--- a/examples/two_clients.rs
+++ b/examples/two_clients.rs
@@ -13,13 +13,14 @@ extern crate tarpc;
 extern crate bincode;
 extern crate env_logger;
 extern crate futures;
+extern crate tokio_core;
 
 use bar::FutureServiceExt as BarExt;
 use baz::FutureServiceExt as BazExt;
-use futures::Future;
 use tarpc::{client, server};
 use tarpc::client::sync::Connect;
 use tarpc::util::{FirstSocketAddr, Never};
+use tokio_core::reactor;
 
 mod bar {
     service! {
@@ -59,17 +60,25 @@ macro_rules! pos {
 
 fn main() {
     let _ = env_logger::init();
-    let bar_addr = Bar.listen("localhost:0".first_socket_addr(),
-                server::Options::default())
-        .wait()
-        .unwrap();
-    let baz_addr = Baz.listen("localhost:0".first_socket_addr(),
-                server::Options::default())
-        .wait()
-        .unwrap();
+    let mut bar_client = {
+        let reactor = reactor::Core::new().unwrap();
+        let addr = Bar.listen("localhost:0".first_socket_addr(),
+                              server::Options::from(reactor.handle()))
+                      .unwrap();
+        // TODO: Need to set up each client with its own reactor. Should it be shareable across
+        // multiple clients? e.g. Rc<RefCell<Core>> or something similar?
+        bar::SyncClient::connect(addr, client::Options::default().core(reactor)).unwrap()
+    };
 
-    let mut bar_client = bar::SyncClient::connect(bar_addr, client::Options::default()).unwrap();
-    let mut baz_client = baz::SyncClient::connect(baz_addr, client::Options::default()).unwrap();
+    let mut baz_client = {
+        // Need to set up each client with its own reactor.
+        let reactor = reactor::Core::new().unwrap();
+        let addr = Baz.listen("localhost:0".first_socket_addr(),
+                              server::Options::from(reactor.handle()))
+                      .unwrap();
+        baz::SyncClient::connect(addr, client::Options::default().core(reactor)).unwrap()
+    };
+
 
     info!("Result: {:?}", bar_client.bar(17));
 

--- a/examples/two_clients.rs
+++ b/examples/two_clients.rs
@@ -63,20 +63,22 @@ fn main() {
     let mut bar_client = {
         let reactor = reactor::Core::new().unwrap();
         let addr = Bar.listen("localhost:0".first_socket_addr(),
-                              server::Options::from(reactor.handle()))
-                      .unwrap();
+                    &reactor.handle(),
+                    server::Options::default())
+            .unwrap();
         // TODO: Need to set up each client with its own reactor. Should it be shareable across
         // multiple clients? e.g. Rc<RefCell<Core>> or something similar?
-        bar::SyncClient::connect(addr, client::Options::default().core(reactor)).unwrap()
+        bar::SyncClient::connect(addr, client::Options::default()).unwrap()
     };
 
     let mut baz_client = {
         // Need to set up each client with its own reactor.
         let reactor = reactor::Core::new().unwrap();
         let addr = Baz.listen("localhost:0".first_socket_addr(),
-                              server::Options::from(reactor.handle()))
-                      .unwrap();
-        baz::SyncClient::connect(addr, client::Options::default().core(reactor)).unwrap()
+                    &reactor.handle(),
+                    server::Options::default())
+            .unwrap();
+        baz::SyncClient::connect(addr, client::Options::default()).unwrap()
     };
 
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -310,8 +310,6 @@ pub mod sync {
     pub trait ClientExt: Sized {
         /// Connects to a server located at the given address.
         fn connect<A>(addr: A, options: Options) -> io::Result<Self> where A: ToSocketAddrs;
-        /// Tries to clone the client.
-        fn try_clone(&self) -> io::Result<Self>;
     }
 
     impl<Req, Resp, E> ClientExt for Client<Req, Resp, E>
@@ -328,13 +326,6 @@ pub mod sync {
             Ok(Client {
                 inner: reactor.run(FutureClient::connect(addr, options))?,
                 reactor: reactor,
-            })
-        }
-
-        fn try_clone(&self) -> io::Result<Self> {
-            Ok(Client {
-                inner: self.inner.clone(),
-                reactor: reactor::Core::new()?,
             })
         }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -43,8 +43,12 @@ impl<E: StdError + Deserialize + Serialize + Send + 'static> fmt::Display for Er
 impl<E: StdError + Deserialize + Serialize + Send + 'static> StdError for Error<E> {
     fn description(&self) -> &str {
         match *self {
-            Error::ClientSerialize(_) => "The client failed to serialize the request or deserialize the response.",
-            Error::ServerSerialize(_) => "The server failed to serialize the response or deserialize the request.",
+            Error::ClientSerialize(_) => {
+                "The client failed to serialize the request or deserialize the response."
+            }
+            Error::ServerSerialize(_) => {
+                "The server failed to serialize the response or deserialize the request."
+            }
             Error::App(ref e) => e.description(),
             Error::Io(ref e) => e.description(),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //! extern crate tokio_core;
 //!
 //! use tarpc::{client, server};
-//! use tarpc::client::sync::Connect;
+//! use tarpc::client::sync::ClientExt;
 //! use tarpc::util::Never;
 //! use tokio_core::reactor;
 //!
@@ -74,7 +74,7 @@
 //! extern crate tarpc;
 //!
 //! use tarpc::{client, server};
-//! use tarpc::client::sync::Connect;
+//! use tarpc::client::sync::ClientExt;
 //! use tarpc::util::Never;
 //! use tarpc::native_tls::{TlsAcceptor, Pkcs12};
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,8 +110,7 @@
 //! ```
 //!
 #![deny(missing_docs)]
-#![feature(plugin, conservative_impl_trait, never_type, unboxed_closures, specialization,
-           struct_field_attributes)]
+#![feature(plugin, never_type, struct_field_attributes)]
 #![plugin(tarpc_plugins)]
 
 extern crate byteorder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,9 +56,8 @@
 //! fn main() {
 //!     let addr = "localhost:10000";
 //!     let reactor = reactor::Core::new().unwrap();
-//!     let _server = HelloServer.listen(addr, server::Options::from(reactor.handle()));
-//!     let mut client = SyncClient::connect(addr, client::Options::default().core(reactor))
-//!                                 .unwrap();
+//!     let _server = HelloServer.listen(addr, server::Options::default());
+//!     let mut client = SyncClient::connect(addr, client::Options::default()).unwrap();
 //!     println!("{}", client.hello("Mom".to_string()).unwrap());
 //! }
 //! ```

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -858,16 +858,9 @@ mod functional_test {
                 }
             }
 
-            fn get_sync_client<C>(addr: SocketAddr) -> io::Result<C>
-                where C: client::sync::ClientExt
-            {
-                C::connect(addr, get_tls_client_options())
-            }
-
             fn start_server_with_sync_client<C, S>(server: S) -> io::Result<(SocketAddr, C)>
                 where C: client::sync::ClientExt, S: SyncServiceExt
             {
-                let reactor = reactor::Core::new()?;
                 let server_options = get_tls_server_options();
                 let addr = unwrap!(server.listen("localhost:0".first_socket_addr(),
                                                  server_options));

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -582,12 +582,6 @@ macro_rules! service {
                     inner: client_,
                 })
             }
-
-            fn try_clone(&self) -> ::std::io::Result<Self> {
-                Ok(SyncClient {
-                    inner: $crate::client::sync::ClientExt::try_clone(&self.inner)?
-                })
-            }
         }
 
         impl SyncClient {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -12,7 +12,6 @@ use std::mem;
 use tokio_core::io::{EasyBuf, Framed, Io};
 use tokio_proto::multiplex::{ClientProto, ServerProto};
 use tokio_proto::streaming::multiplex::RequestId;
-use util::Debugger;
 
 // `Encode` is the type that `Codec` encodes. `Decode` is the type it decodes.
 pub struct Codec<Encode, Decode> {
@@ -97,7 +96,6 @@ impl<Encode, Decode> tokio_core::io::Codec for Codec<Encode, Decode>
                     // message.
                     self.state = Id;
 
-                    trace!("--> Parsed message: {:?}", Debugger(&result));
                     return Ok(Some((id, result)));
                 }
             }

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License, <LICENSE or http://opensource.org/licenses/MIT>.
 // This file may not be copied, modified, or distributed except according to those terms.
 
-use {REMOTE, Reactor};
 use bincode::serde::DeserializeError;
 use errors::WireError;
 use futures::{self, Async, Future, Stream, future};
@@ -33,23 +32,26 @@ enum Acceptor {
 }
 
 /// Additional options to configure how the server operates.
-#[derive(Default)]
 pub struct Options {
-    reactor: Option<Reactor>,
+    handle: reactor::Handle,
     #[cfg(feature = "tls")]
     tls_acceptor: Option<TlsAcceptor>,
+}
+
+impl From<reactor::Handle> for Options {
+    fn from(handle: reactor::Handle) -> Self {
+        Options {
+            handle: handle,
+            #[cfg(feature = "tls")]
+            tls_acceptor: None,
+        }
+    }
 }
 
 impl Options {
     /// Listen using the given reactor handle.
     pub fn handle(mut self, handle: reactor::Handle) -> Self {
-        self.reactor = Some(Reactor::Handle(handle));
-        self
-    }
-
-    /// Listen using the given reactor remote.
-    pub fn remote(mut self, remote: reactor::Remote) -> Self {
-        self.reactor = Some(Reactor::Remote(remote));
+        self.handle = handle;
         self
     }
 
@@ -66,10 +68,10 @@ impl Options {
 pub type Response<T, E> = Result<T, WireError<E>>;
 
 #[doc(hidden)]
-pub fn listen<S, Req, Resp, E>(new_service: S, addr: SocketAddr, options: Options) -> ListenFuture
+pub fn listen<S, Req, Resp, E>(new_service: S, addr: SocketAddr, options: Options) -> io::Result<SocketAddr>
     where S: NewService<Request = Result<Req, DeserializeError>,
                         Response = Response<Resp, E>,
-                        Error = io::Error> + Send + 'static,
+                        Error = io::Error> + 'static,
           Req: Deserialize + 'static,
           Resp: Serialize + 'static,
           E: Serialize + 'static
@@ -84,47 +86,23 @@ pub fn listen<S, Req, Resp, E>(new_service: S, addr: SocketAddr, options: Option
     #[cfg(not(feature = "tls"))]
     let acceptor = Acceptor::Tcp;
 
-    match options.reactor {
-        None => {
-            let (tx, rx) = futures::oneshot();
-            REMOTE.spawn(move |handle| {
-                Ok(tx.complete(listen_with(new_service, addr, handle.clone(), acceptor)))
-            });
-            ListenFuture { inner: future::Either::A(rx) }
-        }
-        Some(Reactor::Remote(remote)) => {
-            let (tx, rx) = futures::oneshot();
-            remote.spawn(move |handle| {
-                Ok(tx.complete(listen_with(new_service, addr, handle.clone(), acceptor)))
-            });
-            ListenFuture { inner: future::Either::A(rx) }
-        }
-        Some(Reactor::Handle(handle)) => {
-            ListenFuture {
-                inner: future::Either::B(future::ok(listen_with(new_service,
-                                                                addr,
-                                                                handle,
-                                                                acceptor))),
-            }
-        }
-    }
+    listen_with(new_service, addr, options.handle, acceptor)
 }
 
 /// Spawns a service that binds to the given address using the given handle.
 fn listen_with<S, Req, Resp, E>(new_service: S,
                                 addr: SocketAddr,
                                 handle: Handle,
-                                _acceptor: Acceptor)
-                                -> io::Result<SocketAddr>
+                                _acceptor: Acceptor) -> io::Result<SocketAddr>
     where S: NewService<Request = Result<Req, DeserializeError>,
                         Response = Response<Resp, E>,
-                        Error = io::Error> + Send + 'static,
+                        Error = io::Error> + 'static,
           Req: Deserialize + 'static,
           Resp: Serialize + 'static,
           E: Serialize + 'static
 {
     let listener = listener(&addr, &handle)?;
-    let addr = listener.local_addr()?;
+    let addr = listener.local_addr();
 
     let handle2 = handle.clone();
 
@@ -149,7 +127,7 @@ fn listen_with<S, Req, Resp, E>(new_service: S,
         })
         .map_err(|e| error!("While processing incoming connections: {}", e));
     handle.spawn(server);
-    Ok(addr)
+    addr
 }
 
 fn listener(addr: &SocketAddr, handle: &Handle) -> io::Result<TcpListener> {
@@ -175,8 +153,7 @@ fn listener(addr: &SocketAddr, handle: &Handle) -> io::Result<TcpListener> {
 /// A future that resolves to a `ServerHandle`.
 #[doc(hidden)]
 pub struct ListenFuture {
-    inner: future::Either<futures::Oneshot<io::Result<SocketAddr>>,
-                          future::FutureResult<io::Result<SocketAddr>, futures::Canceled>>,
+    inner: future::FutureResult<io::Result<SocketAddr>, futures::Canceled>,
 }
 
 impl Future for ListenFuture {

--- a/src/util.rs
+++ b/src/util.rs
@@ -111,18 +111,3 @@ pub trait FirstSocketAddr: ToSocketAddrs {
 }
 
 impl<A: ToSocketAddrs> FirstSocketAddr for A {}
-
-/// A struct that will format as the contained type if the type impls Debug.
-pub struct Debugger<'a, T: 'a>(pub &'a T);
-
-impl<'a, T: fmt::Debug> fmt::Debug for Debugger<'a, T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "{:?}", self.0)
-    }
-}
-
-impl<'a, T> fmt::Debug for Debugger<'a, T> {
-    default fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        write!(f, "{{not debuggable}}")
-    }
-}


### PR DESCRIPTION
**This builds on #92 (so it should be reviewed after it).**

A few changes are included in this PR. The first listed is the main change and the others are necessary consequences of the first:

1. Removes the `Send` bound from `FutureService`. The `Send` bound is still required for `SyncService`, since clones are sent to new threads for each request. (This is more fodder for the argument that there should be a distinct `Options` struct for each combination of async/sync and client/server.)
2. Makes specifying a reactor handle mandatory for server options; it no longer defaults to the tarpc global `REMOTE` because that would require services to be `Send`.
2. Adds the ability to specify a `reactor::Core` (instead of `Remote` or `Handle`) on `client::Options`. This is important because with just #92 it's not possible to drive other futures with a `SyncClient`. (Not sure how frequently that's needed in *real* code, but combined with change 1., it's hard to write examples without it.).
3. Makes `FutureService::listen` return an `io::Result`rather than a `Future`; the future was never actually necessary and had the unintended consequence of making `SyncService::listen` deadlock when the options specified a handle (because that means the reactor driving the service lives on the same thread that `SyncService` is waiting on).

Additionally, this PR renames the client connect traits to `ClientExt` and adds the missing `try_clone` to the renamed `client::sync::ClientExt`.

Fixes #95 