### PR TITLE
Change bound on FutureService's associated types

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ service! {
 struct HelloServer;
 
 impl FutureService for HelloServer {
-    type HelloFut = futures::Finished<String, Never>;
+    type HelloFut = Result<String, Never>;
 
     fn hello(&self, name: String) -> Self::HelloFut {
-        futures::finished(format!("Hello, {}!", name))
+        Ok(format!("Hello, {}!", name))
     }
 }
 
@@ -187,10 +187,10 @@ service! {
 struct HelloServer;
 
 impl FutureService for HelloServer {
-    type HelloFut = futures::Finished<String, Never>;
+    type HelloFut = Result<String, Never>;
 
     fn hello(&mut self, name: String) -> Self::HelloFut {
-        futures::finished(format!("Hello, {}!", name))
+        Ok(format!("Hello, {}!", name))
     }
 }
 
@@ -264,10 +264,10 @@ and the following future-based trait:
 
 ```rust
 impl FutureService for HelloServer {
-    type HelloFut = futures::Finished<String, Message>;
+    type HelloFut = Result<String, Message>;
 
     fn hello(&mut self, name: String) -> Self::HelloFut {
-        futures::finished(format!("Hello, {}!", name))
+        Ok(format!("Hello, {}!", name))
     }
 }
 ```

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -48,11 +48,11 @@ struct Subscriber {
 }
 
 impl subscriber::FutureService for Subscriber {
-    type ReceiveFut = futures::Finished<(), Never>;
+    type ReceiveFut = Result<(), Never>;
 
     fn receive(&self, message: String) -> Self::ReceiveFut {
         println!("{} received message: {}", self.id, message);
-        futures::finished(())
+        Ok(())
     }
 }
 

--- a/examples/readme_futures.rs
+++ b/examples/readme_futures.rs
@@ -25,10 +25,10 @@ service! {
 struct HelloServer;
 
 impl FutureService for HelloServer {
-    type HelloFut = futures::Finished<String, Never>;
+    type HelloFut = Result<String, Never>;
 
     fn hello(&self, name: String) -> Self::HelloFut {
-        futures::finished(format!("Hello, {}!", name))
+        Ok(format!("Hello, {}!", name))
     }
 }
 

--- a/examples/server_calling_server.rs
+++ b/examples/server_calling_server.rs
@@ -40,10 +40,10 @@ pub mod double {
 struct AddServer;
 
 impl AddFutureService for AddServer {
-    type AddFut = futures::Finished<i32, Never>;
+    type AddFut = Result<i32, Never>;
 
     fn add(&self, x: i32, y: i32) -> Self::AddFut {
-        futures::finished(x + y)
+        Ok(x + y)
     }
 }
 

--- a/examples/throughput.rs
+++ b/examples/throughput.rs
@@ -12,6 +12,7 @@ extern crate lazy_static;
 extern crate tarpc;
 extern crate env_logger;
 extern crate futures;
+extern crate serde;
 
 use futures::Future;
 use std::io::{Read, Write, stdout};
@@ -24,7 +25,7 @@ use tarpc::client::sync::Connect;
 use tarpc::util::{FirstSocketAddr, Never};
 
 lazy_static! {
-    static ref BUF: Arc<Vec<u8>> = Arc::new(gen_vec(CHUNK_SIZE as usize));
+    static ref BUF: Arc<serde::bytes::ByteBuf> = Arc::new(gen_vec(CHUNK_SIZE as usize).into());
 }
 
 fn gen_vec(size: usize) -> Vec<u8> {
@@ -36,17 +37,17 @@ fn gen_vec(size: usize) -> Vec<u8> {
 }
 
 service! {
-    rpc read() -> Arc<Vec<u8>>;
+    rpc read() -> Arc<serde::bytes::ByteBuf>;
 }
 
 #[derive(Clone)]
 struct Server;
 
 impl FutureService for Server {
-    type ReadFut = futures::Finished<Arc<Vec<u8>>, Never>;
+    type ReadFut = Result<Arc<serde::bytes::ByteBuf>, Never>;
 
     fn read(&self) -> Self::ReadFut {
-        futures::finished(BUF.clone())
+        Ok(BUF.clone())
     }
 }
 

--- a/examples/two_clients.rs
+++ b/examples/two_clients.rs
@@ -30,10 +30,10 @@ mod bar {
 #[derive(Clone)]
 struct Bar;
 impl bar::FutureService for Bar {
-    type BarFut = futures::Finished<i32, Never>;
+    type BarFut = Result<i32, Never>;
 
     fn bar(&self, i: i32) -> Self::BarFut {
-        futures::finished(i)
+        Ok(i)
     }
 }
 
@@ -46,10 +46,10 @@ mod baz {
 #[derive(Clone)]
 struct Baz;
 impl baz::FutureService for Baz {
-    type BazFut = futures::Finished<String, Never>;
+    type BazFut = Result<String, Never>;
 
     fn baz(&self, s: String) -> Self::BazFut {
-        futures::finished(format!("Hello, {}!", s))
+        Ok(format!("Hello, {}!", s))
     }
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -107,7 +107,9 @@ macro_rules! impl_deserialize {
                 impl $crate::serde::de::Visitor for Visitor {
                     type Value = $impler;
 
-                    fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                    fn expecting(&self, formatter: &mut ::std::fmt::Formatter)
+                        -> ::std::fmt::Result
+                    {
                         formatter.write_str("an enum variant")
                     }
 
@@ -328,7 +330,7 @@ macro_rules! service {
 
                 snake_to_camel! {
                     /// The type of future returned by `{}`.
-                    type $fn_name: $crate::futures::Future<Item=$out, Error=$error>;
+                    type $fn_name: $crate::futures::IntoFuture<Item=$out, Error=$error>;
                 }
 
                 $(#[$attr])*
@@ -371,10 +373,12 @@ macro_rules! service {
                 enum tarpc_service_FutureReply__<tarpc_service_S__: FutureService> {
                     DeserializeError(tarpc_service_Future__),
                     $($fn_name(
-                            $crate::futures::Then<ty_snake_to_camel!(tarpc_service_S__::$fn_name),
-                                                  tarpc_service_Future__,
-                                                  fn(::std::result::Result<$out, $error>)
-                                                      -> tarpc_service_Future__>)),*
+                            $crate::futures::Then<
+                                <ty_snake_to_camel!(tarpc_service_S__::$fn_name)
+                                    as $crate::futures::IntoFuture>::Future,
+                                tarpc_service_Future__,
+                                fn(::std::result::Result<$out, $error>)
+                                    -> tarpc_service_Future__>)),*
                 }
 
                 impl<S: FutureService> $crate::futures::Future for tarpc_service_FutureReply__<S> {
@@ -447,7 +451,8 @@ macro_rules! service {
                                     }
                                     return tarpc_service_FutureReply__::$fn_name(
                                         $crate::futures::Future::then(
-                                                FutureService::$fn_name(&self.0, $($arg),*),
+                                                $crate::futures::IntoFuture::into_future(
+                                                    FutureService::$fn_name(&self.0, $($arg),*)),
                                                 tarpc_service_wrap__));
                                 }
                             )*


### PR DESCRIPTION
Changes the bound on `FutureService`'s associated types from `Future` => `IntoFuture`.

It's strictly more flexible, because everything that impls `Future` impls `IntoFuture`, and it
additionally allows returning types like `Result`. Which is nice. It also makes examples look nicer.

Fixes #87