### PR TITLE
fix(bincode): updates to support bincode 1.0.0-alpha2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 description = "An RPC framework for Rust with a focus on ease of use."
 
 [dependencies]
-bincode = "1.0.0-alpha"
+bincode = "1.0.0-alpha2"
 byteorder = "1.0"
 cfg-if = "0.1.0"
 bytes = "0.3"

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,7 +4,7 @@
 // This file may not be copied, modified, or distributed except according to those terms.
 
 use {Reactor, WireError};
-use bincode::serde::DeserializeError;
+use bincode;
 use futures::{self, Future};
 use protocol::Proto;
 #[cfg(feature = "tls")]
@@ -18,7 +18,7 @@ use tokio_proto::BindClient as ProtoBindClient;
 use tokio_proto::multiplex::Multiplex;
 use tokio_service::Service;
 
-type WireResponse<Resp, E> = Result<Result<Resp, WireError<E>>, DeserializeError>;
+type WireResponse<Resp, E> = Result<Result<Resp, WireError<E>>, bincode::Error>;
 type ResponseFuture<Req, Resp, E> = futures::Map<<BindClient<Req, Resp, E> as Service>::Future,
                                             fn(WireResponse<Resp, E>) -> Result<Resp, ::Error<E>>>;
 type BindClient<Req, Resp, E> = <Proto<Req, Result<Resp, WireError<E>>> as
@@ -117,7 +117,7 @@ impl<Req, Resp, E> Client<Req, Resp, E>
 
     fn map_err(resp: WireResponse<Resp, E>) -> Result<Resp, ::Error<E>> {
         resp.map(|r| r.map_err(::Error::from))
-            .map_err(::Error::ClientDeserialize)
+            .map_err(::Error::ClientSerialize)
             .and_then(|r| r)
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,7 +3,6 @@
 // Licensed under the MIT License, <LICENSE or http://opensource.org/licenses/MIT>.
 // This file may not be copied, modified, or distributed except according to those terms.
 
-use bincode;
 use serde::{Deserialize, Serialize};
 use std::{fmt, io};
 use std::error::Error as StdError;
@@ -13,23 +12,15 @@ use std::error::Error as StdError;
 pub enum Error<E> {
     /// Any IO error.
     Io(io::Error),
-    /// Error in deserializing a server response.
+    /// Error serializing the client request or deserializing the server response.
     ///
     /// Typically this indicates a faulty implementation of `serde::Serialize` or
     /// `serde::Deserialize`.
-    ClientDeserialize(bincode::serde::DeserializeError),
-    /// Error in serializing a client request.
-    ///
-    /// Typically this indicates a faulty implementation of `serde::Serialize`.
-    ClientSerialize(bincode::serde::SerializeError),
-    /// Error in deserializing a client request.
+    ClientSerialize(::bincode::Error),
+    /// Error serializing the server response or deserializing the client request.
     ///
     /// Typically this indicates a faulty implementation of `serde::Serialize` or
     /// `serde::Deserialize`.
-    ServerDeserialize(String),
-    /// Error in serializing a server response.
-    ///
-    /// Typically this indicates a faulty implementation of `serde::Serialize`.
     ServerSerialize(String),
     /// The server was unable to reply to the rpc for some reason.
     ///
@@ -41,9 +32,7 @@ pub enum Error<E> {
 impl<E: StdError + Deserialize + Serialize + Send + 'static> fmt::Display for Error<E> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::ClientDeserialize(ref e) => write!(f, r#"{}: "{}""#, self.description(), e),
             Error::ClientSerialize(ref e) => write!(f, r#"{}: "{}""#, self.description(), e),
-            Error::ServerDeserialize(ref e) => write!(f, r#"{}: "{}""#, self.description(), e),
             Error::ServerSerialize(ref e) => write!(f, r#"{}: "{}""#, self.description(), e),
             Error::App(ref e) => fmt::Display::fmt(e, f),
             Error::Io(ref e) => fmt::Display::fmt(e, f),
@@ -54,10 +43,8 @@ impl<E: StdError + Deserialize + Serialize + Send + 'static> fmt::Display for Er
 impl<E: StdError + Deserialize + Serialize + Send + 'static> StdError for Error<E> {
     fn description(&self) -> &str {
         match *self {
-            Error::ClientDeserialize(_) => "The client failed to deserialize the server response.",
-            Error::ClientSerialize(_) => "The client failed to serialize the request.",
-            Error::ServerDeserialize(_) => "The server failed to deserialize the request.",
-            Error::ServerSerialize(_) => "The server failed to serialize the response.",
+            Error::ClientSerialize(_) => "The client failed to serialize the request or deserialize the response.",
+            Error::ServerSerialize(_) => "The server failed to serialize the response or deserialize the request.",
             Error::App(ref e) => e.description(),
             Error::Io(ref e) => e.description(),
         }
@@ -65,9 +52,7 @@ impl<E: StdError + Deserialize + Serialize + Send + 'static> StdError for Error<
 
     fn cause(&self) -> Option<&StdError> {
         match *self {
-            Error::ClientDeserialize(ref e) => e.cause(),
             Error::ClientSerialize(ref e) => e.cause(),
-            Error::ServerDeserialize(_) |
             Error::ServerSerialize(_) |
             Error::App(_) => None,
             Error::Io(ref e) => e.cause(),
@@ -84,7 +69,6 @@ impl<E> From<io::Error> for Error<E> {
 impl<E> From<WireError<E>> for Error<E> {
     fn from(err: WireError<E>) -> Self {
         match err {
-            WireError::ServerDeserialize(s) => Error::ServerDeserialize(s),
             WireError::ServerSerialize(s) => Error::ServerSerialize(s),
             WireError::App(e) => Error::App(e),
         }
@@ -95,9 +79,7 @@ impl<E> From<WireError<E>> for Error<E> {
 #[doc(hidden)]
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub enum WireError<E> {
-    /// Error in deserializing a client request.
-    ServerDeserialize(String),
-    /// Error in serializing server response.
+    /// Error in serializing the server response or deserializing the client request.
     ServerSerialize(String),
     /// The server was unable to reply to the rpc for some reason.
     App(E),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -408,7 +408,7 @@ macro_rules! service {
                     where tarpc_service_S__: FutureService
                 {
                     type Request = ::std::result::Result<tarpc_service_Request__,
-                                                         $crate::bincode::serde::DeserializeError>;
+                                                         $crate::bincode::Error>;
                     type Response = $crate::server::Response<tarpc_service_Response__,
                                                      tarpc_service_Error__>;
                     type Error = ::std::io::Error;
@@ -421,7 +421,7 @@ macro_rules! service {
                                 return tarpc_service_FutureReply__::DeserializeError(
                                     $crate::futures::finished(
                                         ::std::result::Result::Err(
-                                            $crate::WireError::ServerDeserialize(
+                                            $crate::WireError::ServerSerialize(
                                                 ::std::string::ToString::to_string(
                                                     &tarpc_service_deserialize_err__)))));
                             }
@@ -667,14 +667,8 @@ macro_rules! service {
                                             unreachable!()
                                         }
                                     }
-                                    $crate::Error::ServerDeserialize(tarpc_service_err__) => {
-                                        $crate::Error::ServerDeserialize(tarpc_service_err__)
-                                    }
                                     $crate::Error::ServerSerialize(tarpc_service_err__) => {
                                         $crate::Error::ServerSerialize(tarpc_service_err__)
-                                    }
-                                    $crate::Error::ClientDeserialize(tarpc_service_err__) => {
-                                        $crate::Error::ClientDeserialize(tarpc_service_err__)
                                     }
                                     $crate::Error::ClientSerialize(tarpc_service_err__) => {
                                         $crate::Error::ClientSerialize(tarpc_service_err__)
@@ -913,8 +907,8 @@ mod functional_test {
                                                               Server>(Server);
             let client = client.expect("Could not connect!");
             match client.foo().err().expect("failed unwrap") {
-                ::Error::ServerDeserialize(_) => {} // good
-                bad => panic!("Expected Error::ServerDeserialize but got {}", bad),
+                ::Error::ServerSerialize(_) => {} // good
+                bad => panic!("Expected Error::ServerSerialize but got {}", bad),
             }
         }
     }
@@ -968,8 +962,8 @@ mod functional_test {
                 start_server_with_async_client::<super::other_service::FutureClient,
                                                  Server>(Server);
             match client.foo().wait().err().unwrap() {
-                ::Error::ServerDeserialize(_) => {} // good
-                bad => panic!(r#"Expected Error::ServerDeserialize but got "{}""#, bad),
+                ::Error::ServerSerialize(_) => {} // good
+                bad => panic!(r#"Expected Error::ServerSerialize but got "{}""#, bad),
             }
         }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@
 // This file may not be copied, modified, or distributed except according to those terms.
 
 use {serde, tokio_core};
-use bincode::{SizeLimit, serde as bincode};
+use bincode::{self, SizeLimit};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use std::io::{self, Cursor};
 use std::marker::PhantomData;
@@ -40,7 +40,7 @@ impl<Encode, Decode> tokio_core::io::Codec for Codec<Encode, Decode>
           Decode: serde::Deserialize
 {
     type Out = (RequestId, Encode);
-    type In = (RequestId, Result<Decode, bincode::DeserializeError>);
+    type In = (RequestId, Result<Decode, bincode::Error>);
 
     fn encode(&mut self, (id, message): Self::Out, buf: &mut Vec<u8>) -> io::Result<()> {
         buf.write_u64::<BigEndian>(id).unwrap();
@@ -121,7 +121,7 @@ impl<T, Encode, Decode> ServerProto<T> for Proto<Encode, Decode>
           Decode: serde::Deserialize + 'static
 {
     type Response = Encode;
-    type Request = Result<Decode, bincode::DeserializeError>;
+    type Request = Result<Decode, bincode::Error>;
     type Transport = Framed<T, Codec<Encode, Decode>>;
     type BindTransport = Result<Self::Transport, io::Error>;
 
@@ -135,7 +135,7 @@ impl<T, Encode, Decode> ClientProto<T> for Proto<Encode, Decode>
           Encode: serde::Serialize + 'static,
           Decode: serde::Deserialize + 'static
 {
-    type Response = Result<Decode, bincode::DeserializeError>;
+    type Response = Result<Decode, bincode::Error>;
     type Request = Encode;
     type Transport = Framed<T, Codec<Encode, Decode>>;
     type BindTransport = Result<Self::Transport, io::Error>;
@@ -158,8 +158,8 @@ fn serialize() {
         let mut codec: Codec<(char, char, char), (char, char, char)> = Codec::new();
         codec.encode(MSG, &mut vec).unwrap();
         buf.get_mut().append(&mut vec);
-        let actual: Result<Option<(u64, Result<(char, char, char), bincode::DeserializeError>)>,
-                           io::Error> = codec.decode(&mut buf);
+        let actual: Result<Option<(u64, Result<(char, char, char), bincode::Error>)>, io::Error> =
+            codec.decode(&mut buf);
 
         match actual {
             Ok(Some((id, ref v))) if id == MSG.0 && *v.as_ref().unwrap() == MSG.1 => {}

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,7 +4,7 @@
 // This file may not be copied, modified, or distributed except according to those terms.
 
 use {REMOTE, Reactor};
-use bincode::serde::DeserializeError;
+use bincode;
 use errors::WireError;
 use futures::{self, Async, Future, Stream, future};
 use net2;
@@ -67,7 +67,7 @@ pub type Response<T, E> = Result<T, WireError<E>>;
 
 #[doc(hidden)]
 pub fn listen<S, Req, Resp, E>(new_service: S, addr: SocketAddr, options: Options) -> ListenFuture
-    where S: NewService<Request = Result<Req, DeserializeError>,
+    where S: NewService<Request = Result<Req, bincode::Error>,
                         Response = Response<Resp, E>,
                         Error = io::Error> + Send + 'static,
           Req: Deserialize + 'static,
@@ -116,7 +116,7 @@ fn listen_with<S, Req, Resp, E>(new_service: S,
                                 handle: Handle,
                                 _acceptor: Acceptor)
                                 -> io::Result<SocketAddr>
-    where S: NewService<Request = Result<Req, DeserializeError>,
+    where S: NewService<Request = Result<Req, bincode::Error>,
                         Response = Response<Resp, E>,
                         Error = io::Error> + Send + 'static,
           Req: Deserialize + 'static,


### PR DESCRIPTION
So it looks like bincode 1.0.0-alpha1 isn't compatible with bincode 1.0.0-alpha2.

These changes should fix the breaking build for now.

From what I read in the bincode repo 1.0.0 should come out soon so we can update the dependency accordingly when it does.