### PR TITLE
Return a concrete type from server::listen

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ tarpc has two APIs: `sync` for blocking code and `future` for asynchronous
 code. Here's how to use the sync api.
 
 ```rust
-// required by `FutureClient` (not used directly in this example)
-#![feature(conservative_impl_trait, plugin)]
+#![feature(plugin)]
 #![plugin(tarpc_plugins)]
 
 #[macro_use]
@@ -101,7 +100,7 @@ races! See the `tarpc_examples` package for more examples.
 Here's the same service, implemented using futures.
 
 ```rust
-#![feature(conservative_impl_trait, plugin)]
+#![feature(plugin)]
 #![plugin(tarpc_plugins)]
 
 extern crate futures;
@@ -172,7 +171,7 @@ However, if you are working with both stream types, ensure that you use the TLS 
 servers and TCP clients with TCP servers.
 
 ```rust,no_run
-#![feature(conservative_impl_trait, plugin)]
+#![feature(plugin)]
 #![plugin(tarpc_plugins)]
 
 extern crate futures;

--- a/benches/latency.rs
+++ b/benches/latency.rs
@@ -40,10 +40,11 @@ impl FutureService for Server {
 fn latency(bencher: &mut Bencher) {
     let _ = env_logger::init();
     let mut reactor = reactor::Core::new().unwrap();
-    let addr = Server.listen("localhost:0".first_socket_addr(),
+    let (addr, server) = Server.listen("localhost:0".first_socket_addr(),
                 &reactor.handle(),
                 server::Options::default())
         .unwrap();
+    reactor.handle().spawn(server);
     let client = reactor.run(FutureClient::connect(addr, client::Options::default())).unwrap();
 
     bencher.iter(|| reactor.run(client.ack()).unwrap());

--- a/benches/latency.rs
+++ b/benches/latency.rs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License, <LICENSE or http://opensource.org/licenses/MIT>.
 // This file may not be copied, modified, or distributed except according to those terms.
 
-#![feature(plugin, conservative_impl_trait, test)]
+#![feature(plugin, test)]
 #![plugin(tarpc_plugins)]
 
 #[macro_use]

--- a/examples/concurrency.rs
+++ b/examples/concurrency.rs
@@ -167,11 +167,12 @@ fn main() {
         .unwrap_or(4);
 
     let mut reactor = reactor::Core::new().unwrap();
-    let addr = Server::new()
+    let (addr, server) = Server::new()
         .listen("localhost:0".first_socket_addr(),
                 &reactor.handle(),
                 server::Options::default())
         .unwrap();
+    reactor.handle().spawn(server);
     info!("Server listening on {}.", addr);
 
     let clients = (0..num_clients)

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License, <LICENSE or http://opensource.org/licenses/MIT>.
 // This file may not be copied, modified, or distributed except according to those terms.
 
-#![feature(conservative_impl_trait, plugin)]
+#![feature(plugin)]
 #![plugin(tarpc_plugins)]
 
 extern crate env_logger;

--- a/examples/readme_errors.rs
+++ b/examples/readme_errors.rs
@@ -19,7 +19,6 @@ use std::sync::mpsc;
 use std::thread;
 use tarpc::{client, server};
 use tarpc::client::sync::ClientExt;
-use tarpc::util::FirstSocketAddr;
 
 service! {
     rpc hello(name: String) -> String | NoNameGiven;

--- a/examples/readme_errors.rs
+++ b/examples/readme_errors.rs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License, <LICENSE or http://opensource.org/licenses/MIT>.
 // This file may not be copied, modified, or distributed except according to those terms.
 
-#![feature(conservative_impl_trait, plugin)]
+#![feature(plugin)]
 #![plugin(tarpc_plugins)]
 
 extern crate futures;

--- a/examples/readme_futures.rs
+++ b/examples/readme_futures.rs
@@ -34,10 +34,12 @@ impl FutureService for HelloServer {
 
 fn main() {
     let mut reactor = reactor::Core::new().unwrap();
-    let addr = HelloServer.listen("localhost:10000".first_socket_addr(),
+    let (addr, server) = HelloServer.listen("localhost:10000".first_socket_addr(),
                 &reactor.handle(),
                 server::Options::default())
         .unwrap();
+    reactor.handle().spawn(server);
+
     let options = client::Options::default().handle(reactor.handle());
     reactor.run(FutureClient::connect(addr, options)
             .map_err(tarpc::Error::from)

--- a/examples/readme_futures.rs
+++ b/examples/readme_futures.rs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License, <LICENSE or http://opensource.org/licenses/MIT>.
 // This file may not be copied, modified, or distributed except according to those terms.
 
-#![feature(conservative_impl_trait, plugin)]
+#![feature(plugin)]
 #![plugin(tarpc_plugins)]
 
 extern crate futures;

--- a/examples/readme_sync.rs
+++ b/examples/readme_sync.rs
@@ -4,7 +4,7 @@
 // This file may not be copied, modified, or distributed except according to those terms.
 
 // required by `FutureClient` (not used directly in this example)
-#![feature(conservative_impl_trait, plugin)]
+#![feature(plugin)]
 #![plugin(tarpc_plugins)]
 
 extern crate futures;

--- a/examples/readme_sync.rs
+++ b/examples/readme_sync.rs
@@ -16,7 +16,7 @@ use std::sync::mpsc;
 use std::thread;
 use tarpc::{client, server};
 use tarpc::client::sync::ClientExt;
-use tarpc::util::{FirstSocketAddr, Never};
+use tarpc::util::Never;
 
 service! {
     rpc hello(name: String) -> String;

--- a/examples/server_calling_server.rs
+++ b/examples/server_calling_server.rs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License, <LICENSE or http://opensource.org/licenses/MIT>.
 // This file may not be copied, modified, or distributed except according to those terms.
 
-#![feature(conservative_impl_trait, plugin)]
+#![feature(plugin)]
 #![plugin(tarpc_plugins)]
 
 extern crate env_logger;

--- a/examples/server_calling_server.rs
+++ b/examples/server_calling_server.rs
@@ -72,19 +72,21 @@ impl DoubleFutureService for DoubleServer {
 fn main() {
     let _ = env_logger::init();
     let mut reactor = reactor::Core::new().unwrap();
-    let add_addr = AddServer.listen("localhost:0".first_socket_addr(),
+    let (add_addr, server) = AddServer.listen("localhost:0".first_socket_addr(),
                 &reactor.handle(),
                 server::Options::default())
         .unwrap();
+    reactor.handle().spawn(server);
 
     let options = client::Options::default().handle(reactor.handle());
     let add_client = reactor.run(add::FutureClient::connect(add_addr, options)).unwrap();
 
-    let double_addr = DoubleServer::new(add_client)
+    let (double_addr, server) = DoubleServer::new(add_client)
         .listen("localhost:0".first_socket_addr(),
                 &reactor.handle(),
                 server::Options::default())
         .unwrap();
+    reactor.handle().spawn(server);
 
     let double_client =
         reactor.run(double::FutureClient::connect(double_addr, client::Options::default()))

--- a/examples/throughput.rs
+++ b/examples/throughput.rs
@@ -56,10 +56,11 @@ const CHUNK_SIZE: u32 = 1 << 19;
 
 fn bench_tarpc(target: u64) {
     let reactor = reactor::Core::new().unwrap();
-    let addr = Server.listen("localhost:0".first_socket_addr(),
+    let (addr, server) = Server.listen("localhost:0".first_socket_addr(),
                 &reactor.handle(),
                 server::Options::default())
         .unwrap();
+    reactor.handle().spawn(server);
     let mut client = SyncClient::connect(addr, client::Options::default()).unwrap();
     let start = time::Instant::now();
     let mut nread = 0;

--- a/examples/throughput.rs
+++ b/examples/throughput.rs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License, <LICENSE or http://opensource.org/licenses/MIT>.
 // This file may not be copied, modified, or distributed except according to those terms.
 
-#![feature(conservative_impl_trait, plugin)]
+#![feature(plugin)]
 #![plugin(tarpc_plugins)]
 
 #[macro_use]

--- a/examples/two_clients.rs
+++ b/examples/two_clients.rs
@@ -3,7 +3,7 @@
 // Licensed under the MIT License, <LICENSE or http://opensource.org/licenses/MIT>.
 // This file may not be copied, modified, or distributed except according to those terms.
 
-#![feature(conservative_impl_trait, plugin)]
+#![feature(plugin)]
 #![plugin(tarpc_plugins)]
 
 #[macro_use]

--- a/examples/two_clients.rs
+++ b/examples/two_clients.rs
@@ -67,8 +67,9 @@ fn main() {
         thread::spawn(move || {
             let mut reactor = reactor::Core::new().unwrap();
             let (addr, server) = Bar.listen("localhost:0".first_socket_addr(),
-                                            &reactor.handle(),
-                                            server::Options::default()).unwrap();
+                        &reactor.handle(),
+                        server::Options::default())
+                .unwrap();
             tx.send(addr).unwrap();
             reactor.run(server).unwrap();
         });
@@ -81,8 +82,9 @@ fn main() {
         thread::spawn(move || {
             let mut reactor = reactor::Core::new().unwrap();
             let (addr, server) = Baz.listen("localhost:0".first_socket_addr(),
-                                            &reactor.handle(),
-                                            server::Options::default()).unwrap();
+                        &reactor.handle(),
+                        server::Options::default())
+                .unwrap();
             tx.send(addr).unwrap();
             reactor.run(server).unwrap();
         });

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,9 +3,9 @@
 // Licensed under the MIT License, <LICENSE or http://opensource.org/licenses/MIT>.
 // This file may not be copied, modified, or distributed except according to those terms.
 
-use {WireError, bincode};
 #[cfg(feature = "tls")]
 use self::tls::*;
+use {WireError, bincode};
 use tokio_core::reactor;
 
 type WireResponse<Resp, E> = Result<Result<Resp, WireError<E>>, bincode::Error>;
@@ -86,6 +86,7 @@ enum Reactor {
 
 /// Exposes a trait for connecting asynchronously to servers.
 pub mod future {
+    use super::{Options, Reactor, WireResponse};
     use {REMOTE, WireError};
     #[cfg(feature = "tls")]
     use errors::native_to_io;
@@ -96,7 +97,6 @@ pub mod future {
     use std::io;
     use std::net::SocketAddr;
     use stream_type::StreamType;
-    use super::{Options, Reactor, WireResponse};
     use tokio_core::net::TcpStream;
     use tokio_core::reactor;
     use tokio_proto::BindClient as ProtoBindClient;
@@ -264,13 +264,13 @@ pub mod future {
 
 /// Exposes a trait for connecting synchronously to servers.
 pub mod sync {
+    use super::Options;
+    use super::Reactor;
+    use super::future::{Client as FutureClient, ClientExt as FutureClientExt};
     use serde::{Deserialize, Serialize};
     use std::fmt;
     use std::io;
     use std::net::ToSocketAddrs;
-    use super::Options;
-    use super::Reactor;
-    use super::future::{Client as FutureClient, ClientExt as FutureClientExt};
     use tokio_core::reactor;
     use tokio_service::Service;
     use util::FirstSocketAddr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,7 @@
 //! Example usage:
 //!
 //! ```
-//! // required by `FutureClient` (not used in this example)
-//! #![feature(conservative_impl_trait, plugin)]
+//! #![feature(plugin)]
 //! #![plugin(tarpc_plugins)]
 //!
 //! #[macro_use]
@@ -72,8 +71,7 @@
 //! Example usage with TLS:
 //!
 //! ```ignore
-//! // required by `FutureClient` (not used in this example)
-//! #![feature(conservative_impl_trait, plugin)]
+//! #![feature(plugin)]
 //! #![plugin(tarpc_plugins)]
 //!
 //! #[macro_use]
@@ -116,7 +114,7 @@
 //! ```
 //!
 #![deny(missing_docs)]
-#![feature(conservative_impl_trait, never_type, plugin, struct_field_attributes, fn_traits, unboxed_closures)]
+#![feature(never_type, plugin, struct_field_attributes, fn_traits, unboxed_closures)]
 #![plugin(tarpc_plugins)]
 
 extern crate byteorder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@
 //! ```
 //!
 #![deny(missing_docs)]
-#![feature(conservative_impl_trait, never_type, plugin, struct_field_attributes)]
+#![feature(conservative_impl_trait, never_type, plugin, struct_field_attributes, fn_traits, unboxed_closures)]
 #![plugin(tarpc_plugins)]
 
 extern crate byteorder;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1034,8 +1034,8 @@ mod functional_test {
     }
 
     mod future {
-        use futures::{Finished, finished};
         use super::{FutureClient, FutureService, env_logger, start_server_with_async_client};
+        use futures::{Finished, finished};
         use tokio_core::reactor;
         use util::Never;
 
@@ -1100,8 +1100,8 @@ mod functional_test {
             let _ = env_logger::init();
             let reactor = reactor::Core::new().unwrap();
             let (addr, _) = Server.listen("localhost:0".first_socket_addr(),
-                                               &reactor.handle(),
-                                               server::Options::default())
+                        &reactor.handle(),
+                        server::Options::default())
                 .unwrap();
             Server.listen(addr, &reactor.handle(), server::Options::default()).unwrap();
         }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -153,7 +153,7 @@ macro_rules! impl_deserialize {
 /// Rpc methods are specified, mirroring trait syntax:
 ///
 /// ```
-/// # #![feature(conservative_impl_trait, plugin)]
+/// # #![feature(plugin)]
 /// # #![plugin(tarpc_plugins)]
 /// # #[macro_use] extern crate tarpc;
 /// # fn main() {}
@@ -893,7 +893,8 @@ mod functional_test {
                 let options = get_tls_server_options();
                 let (tx, rx) = ::std::sync::mpsc::channel();
                 ::std::thread::spawn(move || {
-                    let mut handle = unwrap!(server.listen("localhost:0".first_socket_addr(), options));
+                    let mut handle = unwrap!(server.listen("localhost:0".first_socket_addr(),
+                                                           options));
                     tx.send(handle.addr()).unwrap();
                     handle.run();
                 });

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -522,8 +522,9 @@ macro_rules! service {
         /// Provides a function for starting the service. This is a separate trait from
         /// `SyncService` to prevent collisions with the names of RPCs.
         pub trait SyncServiceExt: SyncService {
-            /// Spawns the service, binding to the given address and running on
-            /// the default tokio `Loop`.
+            /// Spawns the service, binding to the given address and returning the server handle.
+            ///
+            /// To actually run the server, call `run` on the returned handle.
             fn listen<A>(self, addr: A, options: $crate::server::Options)
                 -> ::std::io::Result<$crate::server::Handle>
                     where A: ::std::net::ToSocketAddrs

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -487,7 +487,10 @@ macro_rules! service {
         /// `FutureService` to prevent collisions with the names of RPCs.
         pub trait FutureServiceExt: FutureService {
             /// Spawns the service, binding to the given address and running on
-            /// the default tokio `Loop`.
+            /// the `reactor::Core` associated with `handle`.
+            ///
+            /// Returns the address being listened on as well as the server future. The future
+            /// must be executed for the server to run.
             fn listen(self,
                       addr: ::std::net::SocketAddr,
                       handle: &$crate::tokio_core::reactor::Handle,

--- a/src/server.rs
+++ b/src/server.rs
@@ -136,6 +136,7 @@ pub fn listen<S, Req, Resp, E>(new_service: S,
 }
 
 /// A handle to a bound server. Must be run to start serving requests.
+#[must_use]
 pub struct Handle {
     reactor: reactor::Core,
     addr: SocketAddr,

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,21 +5,22 @@
 
 use bincode;
 use errors::WireError;
-use futures::{Future, Stream, future};
+use futures::{Future, Poll, Stream, future, stream};
 use net2;
 use protocol::Proto;
 use serde::{Deserialize, Serialize};
 use std::io;
 use std::net::SocketAddr;
-use tokio_core::net::TcpListener;
+use tokio_core::io::Io;
+use tokio_core::net::{Incoming, TcpListener, TcpStream};
 use tokio_core::reactor;
 use tokio_proto::BindServer;
 use tokio_service::NewService;
 
 cfg_if! {
     if #[cfg(feature = "tls")] {
-        use native_tls::TlsAcceptor;
-        use tokio_tls::TlsAcceptorExt;
+        use native_tls::{self, TlsAcceptor};
+        use tokio_tls::{AcceptAsync, TlsAcceptorExt, TlsStream};
         use errors::native_to_io;
         use stream_type::StreamType;
     } else {}
@@ -29,6 +30,54 @@ enum Acceptor {
     Tcp,
     #[cfg(feature = "tls")]
     Tls(TlsAcceptor),
+}
+
+#[cfg(feature = "tls")]
+type Accept = future::Either<
+            future::MapErr<future::Map<AcceptAsync<TcpStream>, fn(TlsStream<TcpStream>) -> StreamType>,
+                           fn(native_tls::Error) -> io::Error>,
+            future::FutureResult<StreamType, io::Error>>;
+
+#[cfg(not(feature = "tls"))]
+type Accept = future::FutureResult<TcpStream, io::Error>;
+
+impl Acceptor {
+    #[cfg(feature = "tls")]
+    fn accept(&self, socket: TcpStream) -> Accept {
+        match *self {
+            Acceptor::Tls(ref tls_acceptor) => {
+                future::Either::A(tls_acceptor.accept_async(socket)
+                    .map(StreamType::Tls as _)
+                    .map_err(native_to_io))
+            }
+            Acceptor::Tcp => future::Either::B(future::ok(StreamType::Tcp(socket))),
+        }
+    }
+
+    #[cfg(not(feature = "tls"))]
+    fn accept(&self, socket: TcpStream) -> Accept {
+        future::ok(socket)
+    }
+}
+
+impl FnOnce<((TcpStream, SocketAddr),)> for Acceptor {
+    type Output = Accept;
+
+    extern "rust-call" fn call_once(self, ((socket, _),): ((TcpStream, SocketAddr),)) -> Accept {
+        self.accept(socket)
+    }
+}
+
+impl FnMut<((TcpStream, SocketAddr),)> for Acceptor {
+    extern "rust-call" fn call_mut(&mut self, ((socket, _),): ((TcpStream, SocketAddr),)) -> Accept {
+        self.accept(socket)
+    }
+}
+
+impl Fn<((TcpStream, SocketAddr),)> for Acceptor {
+    extern "rust-call" fn call(&self, ((socket, _),): ((TcpStream, SocketAddr),)) -> Accept {
+        self.accept(socket)
+    }
 }
 
 /// Additional options to configure how the server operates.
@@ -56,7 +105,7 @@ pub fn listen<S, Req, Resp, E>(new_service: S,
                                addr: SocketAddr,
                                handle: &reactor::Handle,
                                _options: Options)
-                               -> io::Result<(SocketAddr, impl Future<Item = (), Error = ()>)>
+                               -> io::Result<(SocketAddr, Listen<S, Req, Resp, E>)>
     where S: NewService<Request = Result<Req, bincode::Error>,
                         Response = Response<Resp, E>,
                         Error = io::Error> + 'static,
@@ -105,12 +154,44 @@ impl Handle {
     }
 }
 
+/// The future representing a running server.
+pub struct Listen<S, Req, Resp, E>
+    where S: NewService<Request = Result<Req, bincode::Error>,
+                        Response = Response<Resp, E>,
+                        Error = io::Error> + 'static,
+          Req: Deserialize + 'static,
+          Resp: Serialize + 'static,
+          E: Serialize + 'static
+{
+    inner: future::MapErr<
+        stream::ForEach<stream::AndThen<Incoming, Acceptor, Accept>,
+                        Bind<S>,
+                        io::Result<()>>,
+        fn(io::Error)>
+}
+
+impl<S, Req, Resp, E> Future for Listen<S, Req, Resp, E>
+    where S: NewService<Request = Result<Req, bincode::Error>,
+                        Response = Response<Resp, E>,
+                        Error = io::Error> + 'static,
+          Req: Deserialize + 'static,
+          Resp: Serialize + 'static,
+          E: Serialize + 'static
+{
+    type Item = ();
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<(), ()> {
+        self.inner.poll()
+    }
+}
+
 /// Spawns a service that binds to the given address using the given handle.
 fn listen_with<S, Req, Resp, E>(new_service: S,
                                 addr: SocketAddr,
                                 handle: &reactor::Handle,
-                                _acceptor: Acceptor)
-                                -> io::Result<(SocketAddr, impl Future<Item = (), Error = ()>)>
+                                acceptor: Acceptor)
+                                -> io::Result<(SocketAddr, Listen<S, Req, Resp, E>)>
     where S: NewService<Request = Result<Req, bincode::Error>,
                         Response = Response<Resp, E>,
                         Error = io::Error> + 'static,
@@ -121,29 +202,82 @@ fn listen_with<S, Req, Resp, E>(new_service: S,
     let listener = listener(&addr, handle)?;
     let addr = listener.local_addr()?;
 
-    let handle2 = handle.clone();
+    let handle = handle.clone();
 
-    let server = listener.incoming()
-        .and_then(move |(socket, _)| {
-            #[cfg(feature = "tls")]
-            match _acceptor {
-                Acceptor::Tls(ref tls_acceptor) => {
-                    future::Either::A(tls_acceptor.accept_async(socket)
-                        .map(StreamType::Tls)
-                        .map_err(native_to_io))
-                }
-                Acceptor::Tcp => future::Either::B(future::ok(StreamType::Tcp(socket))),
-            }
-            #[cfg(not(feature = "tls"))]
-            future::ok(socket)
-        })
-        .for_each(move |socket| {
-            Proto::new().bind_server(&handle2, socket, new_service.new_service()?);
+    let inner = listener.incoming()
+        .and_then(acceptor)
+        .for_each(Bind { handle, new_service })
+        .map_err(log_err as _);
+    Ok((addr, Listen { inner }))
+}
 
-            Ok(())
-        })
-        .map_err(|e| error!("While processing incoming connections: {}", e));
-    Ok((addr, server))
+fn log_err(e: io::Error) {
+    error!("While processing incoming connections: {}", e);
+}
+
+struct Bind<S> {
+    handle: reactor::Handle,
+    new_service: S,
+}
+
+impl<S, Req, Resp, E> Bind<S>
+    where S: NewService<Request = Result<Req, bincode::Error>,
+                            Response = Response<Resp, E>,
+                            Error = io::Error> + 'static,
+          Req: Deserialize + 'static,
+          Resp: Serialize + 'static,
+          E: Serialize + 'static
+{
+    fn bind<I>(&self, socket: I) -> io::Result<()>
+        where I: Io + 'static
+    {
+        Proto::new().bind_server(&self.handle, socket, self.new_service.new_service()?);
+        Ok(())
+    }
+}
+
+impl<I, S, Req, Resp, E> FnOnce<(I,)> for Bind<S>
+    where I: Io + 'static,
+          S: NewService<Request = Result<Req, bincode::Error>,
+                            Response = Response<Resp, E>,
+                            Error = io::Error> + 'static,
+          Req: Deserialize + 'static,
+          Resp: Serialize + 'static,
+          E: Serialize + 'static
+{
+    type Output = io::Result<()>;
+
+    extern "rust-call" fn call_once(self, (socket,): (I,)) -> io::Result<()> {
+        self.bind(socket)
+    }
+}
+
+impl<I, S, Req, Resp, E> FnMut<(I,)> for Bind<S>
+    where I: Io + 'static,
+          S: NewService<Request = Result<Req, bincode::Error>,
+                            Response = Response<Resp, E>,
+                            Error = io::Error> + 'static,
+          Req: Deserialize + 'static,
+          Resp: Serialize + 'static,
+          E: Serialize + 'static
+{
+    extern "rust-call" fn call_mut(&mut self, (socket,): (I,)) -> io::Result<()> {
+        self.bind(socket)
+    }
+}
+
+impl<I, S, Req, Resp, E> Fn<(I,)> for Bind<S>
+    where I: Io + 'static,
+          S: NewService<Request = Result<Req, bincode::Error>,
+                            Response = Response<Resp, E>,
+                            Error = io::Error> + 'static,
+          Req: Deserialize + 'static,
+          Resp: Serialize + 'static,
+          E: Serialize + 'static
+{
+    extern "rust-call" fn call(&self, (socket,): (I,)) -> io::Result<()> {
+        self.bind(socket)
+    }
 }
 
 fn listener(addr: &SocketAddr, handle: &reactor::Handle) -> io::Result<TcpListener> {

--- a/src/server.rs
+++ b/src/server.rs
@@ -136,7 +136,7 @@ pub fn listen<S, Req, Resp, E>(new_service: S,
 }
 
 /// A handle to a bound server. Must be run to start serving requests.
-#[must_use]
+#[must_use = "A server does nothing until `run` is called."]
 pub struct Handle {
     reactor: reactor::Core,
     addr: SocketAddr,


### PR DESCRIPTION
And change FutureServiceExt::listen to return `(SocketAddr, Listen)`. The macro now generates a new public item called `Listen` that impls `Future<Item=(), Error=()>`.