### PR TITLE
Add server::Handle::shutdown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ description = "An RPC framework for Rust with a focus on ease of use."
 travis-ci = { repository = "google/tarpc" }
 
 [dependencies]
-bincode = { git = "https://github.com/tikue/bincode", branch = "faster-byte-buf-deserialization" }
+bincode = "1.0.0-alpha2"
 byteorder = "1.0"
 cfg-if = "0.1.0"
 futures = "0.1.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ description = "An RPC framework for Rust with a focus on ease of use."
 travis-ci = { repository = "google/tarpc" }
 
 [dependencies]
-bincode = "1.0.0-alpha2"
+bincode = { git = "https://github.com/tikue/bincode", branch = "faster-byte-buf-deserialization" }
 byteorder = "1.0"
 cfg-if = "0.1.0"
 futures = "0.1.7"

--- a/README.md
+++ b/README.md
@@ -131,13 +131,13 @@ impl FutureService for HelloServer {
 
 fn main() {
     let mut reactor = reactor::Core::new().unwrap();
-    let (addr, server) = HelloServer.listen("localhost:10000".first_socket_addr(),
+    let (handle, server) = HelloServer.listen("localhost:10000".first_socket_addr(),
                                   &reactor.handle(),
                                   server::Options::default())
                           .unwrap();
     reactor.handle().spawn(server);
     let options = client::Options::default().handle(reactor.handle());
-    reactor.run(FutureClient::connect(addr, options)
+    reactor.run(FutureClient::connect(handle.addr(), options)
             .map_err(tarpc::Error::from)
             .and_then(|client| client.hello("Mom".to_string()))
             .map(|resp| println!("{}", resp)))
@@ -210,14 +210,14 @@ fn get_acceptor() -> TlsAcceptor {
 fn main() {
     let mut reactor = reactor::Core::new().unwrap();
     let acceptor = get_acceptor();
-    let (addr, server) = HelloServer.listen("localhost:10000".first_socket_addr(),
+    let (handle, server) = HelloServer.listen("localhost:10000".first_socket_addr(),
                                             &reactor.handle(),
                                             server::Options::default().tls(acceptor)).unwrap();
     reactor.handle().spawn(server);
     let options = client::Options::default()
                                    .handle(reactor.handle())
                                    .tls(client::tls::Context::new("foobar.com").unwrap());
-    reactor.run(FutureClient::connect(addr, options)
+    reactor.run(FutureClient::connect(handle.addr(), options)
             .map_err(tarpc::Error::from)
             .and_then(|client| client.hello("Mom".to_string()))
             .map(|resp| println!("{}", resp)))

--- a/benches/latency.rs
+++ b/benches/latency.rs
@@ -40,12 +40,13 @@ impl FutureService for Server {
 fn latency(bencher: &mut Bencher) {
     let _ = env_logger::init();
     let mut reactor = reactor::Core::new().unwrap();
-    let (addr, server) = Server.listen("localhost:0".first_socket_addr(),
+    let (handle, server) = Server.listen("localhost:0".first_socket_addr(),
                 &reactor.handle(),
                 server::Options::default())
         .unwrap();
     reactor.handle().spawn(server);
-    let client = FutureClient::connect(addr, client::Options::default().handle(reactor.handle()));
+    let client = FutureClient::connect(handle.addr(),
+                                       client::Options::default().handle(reactor.handle()));
     let client = reactor.run(client).unwrap();
 
     bencher.iter(|| reactor.run(client.ack()).unwrap());

--- a/examples/concurrency.rs
+++ b/examples/concurrency.rs
@@ -167,20 +167,20 @@ fn main() {
         .unwrap_or(4);
 
     let mut reactor = reactor::Core::new().unwrap();
-    let (addr, server) = Server::new()
+    let (handle, server) = Server::new()
         .listen("localhost:0".first_socket_addr(),
                 &reactor.handle(),
                 server::Options::default())
         .unwrap();
     reactor.handle().spawn(server);
-    info!("Server listening on {}.", addr);
+    info!("Server listening on {}.", handle.addr());
 
     let clients = (0..num_clients)
         // Spin up a couple threads to drive the clients.
         .map(|i| (i, spawn_core()))
         .map(|(i, remote)| {
             info!("Client {} connecting...", i);
-            FutureClient::connect(addr, client::Options::default().remote(remote))
+            FutureClient::connect(handle.addr(), client::Options::default().remote(remote))
                 .map_err(|e| panic!(e))
         });
 

--- a/examples/readme_errors.rs
+++ b/examples/readme_errors.rs
@@ -55,8 +55,7 @@ impl SyncService for HelloServer {
 fn main() {
     let (tx, rx) = mpsc::channel();
     thread::spawn(move || {
-        let mut handle = HelloServer.listen("localhost:10000", server::Options::default())
-            .unwrap();
+        let handle = HelloServer.listen("localhost:10000", server::Options::default()).unwrap();
         tx.send(handle.addr()).unwrap();
         handle.run();
     });

--- a/examples/readme_futures.rs
+++ b/examples/readme_futures.rs
@@ -34,14 +34,14 @@ impl FutureService for HelloServer {
 
 fn main() {
     let mut reactor = reactor::Core::new().unwrap();
-    let (addr, server) = HelloServer.listen("localhost:10000".first_socket_addr(),
+    let (handle, server) = HelloServer.listen("localhost:10000".first_socket_addr(),
                 &reactor.handle(),
                 server::Options::default())
         .unwrap();
     reactor.handle().spawn(server);
 
     let options = client::Options::default().handle(reactor.handle());
-    reactor.run(FutureClient::connect(addr, options)
+    reactor.run(FutureClient::connect(handle.addr(), options)
             .map_err(tarpc::Error::from)
             .and_then(|client| client.hello("Mom".to_string()))
             .map(|resp| println!("{}", resp)))

--- a/examples/readme_sync.rs
+++ b/examples/readme_sync.rs
@@ -34,8 +34,7 @@ impl SyncService for HelloServer {
 fn main() {
     let (tx, rx) = mpsc::channel();
     thread::spawn(move || {
-        let mut handle = HelloServer.listen("localhost:0", server::Options::default())
-            .unwrap();
+        let handle = HelloServer.listen("localhost:0", server::Options::default()).unwrap();
         tx.send(handle.addr()).unwrap();
         handle.run();
     });

--- a/examples/server_calling_server.rs
+++ b/examples/server_calling_server.rs
@@ -72,16 +72,16 @@ impl DoubleFutureService for DoubleServer {
 fn main() {
     let _ = env_logger::init();
     let mut reactor = reactor::Core::new().unwrap();
-    let (add_addr, server) = AddServer.listen("localhost:0".first_socket_addr(),
+    let (add, server) = AddServer.listen("localhost:0".first_socket_addr(),
                 &reactor.handle(),
                 server::Options::default())
         .unwrap();
     reactor.handle().spawn(server);
 
     let options = client::Options::default().handle(reactor.handle());
-    let add_client = reactor.run(add::FutureClient::connect(add_addr, options)).unwrap();
+    let add_client = reactor.run(add::FutureClient::connect(add.addr(), options)).unwrap();
 
-    let (double_addr, server) = DoubleServer::new(add_client)
+    let (double, server) = DoubleServer::new(add_client)
         .listen("localhost:0".first_socket_addr(),
                 &reactor.handle(),
                 server::Options::default())
@@ -89,7 +89,7 @@ fn main() {
     reactor.handle().spawn(server);
 
     let double_client =
-        reactor.run(double::FutureClient::connect(double_addr, client::Options::default()))
+        reactor.run(double::FutureClient::connect(double.addr(), client::Options::default()))
             .unwrap();
     reactor.run(futures::stream::futures_unordered((0..5).map(|i| double_client.double(i)))
             .map_err(|e| println!("{}", e))

--- a/examples/throughput.rs
+++ b/examples/throughput.rs
@@ -66,7 +66,8 @@ fn bench_tarpc(target: u64) {
         tx.send(addr).unwrap();
         reactor.run(server).unwrap();
     });
-    let mut client = SyncClient::connect(rx.recv().unwrap(), client::Options::default()).unwrap();
+    let mut client = SyncClient::connect(rx.recv().unwrap().addr(), client::Options::default())
+        .unwrap();
     let start = time::Instant::now();
     let mut nread = 0;
     while nread < target {

--- a/examples/two_clients.rs
+++ b/examples/two_clients.rs
@@ -66,30 +66,30 @@ fn main() {
         let (tx, rx) = mpsc::channel();
         thread::spawn(move || {
             let mut reactor = reactor::Core::new().unwrap();
-            let (addr, server) = Bar.listen("localhost:0".first_socket_addr(),
+            let (handle, server) = Bar.listen("localhost:0".first_socket_addr(),
                         &reactor.handle(),
                         server::Options::default())
                 .unwrap();
-            tx.send(addr).unwrap();
+            tx.send(handle).unwrap();
             reactor.run(server).unwrap();
         });
-        let addr = rx.recv().unwrap();
-        bar::SyncClient::connect(addr, client::Options::default()).unwrap()
+        let handle = rx.recv().unwrap();
+        bar::SyncClient::connect(handle.addr(), client::Options::default()).unwrap()
     };
 
     let mut baz_client = {
         let (tx, rx) = mpsc::channel();
         thread::spawn(move || {
             let mut reactor = reactor::Core::new().unwrap();
-            let (addr, server) = Baz.listen("localhost:0".first_socket_addr(),
+            let (handle, server) = Baz.listen("localhost:0".first_socket_addr(),
                         &reactor.handle(),
                         server::Options::default())
                 .unwrap();
-            tx.send(addr).unwrap();
+            tx.send(handle).unwrap();
             reactor.run(server).unwrap();
         });
-        let addr = rx.recv().unwrap();
-        baz::SyncClient::connect(addr, client::Options::default()).unwrap()
+        let handle = rx.recv().unwrap();
+        baz::SyncClient::connect(handle.addr(), client::Options::default()).unwrap()
     };
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@
 //! ```
 //!
 #![deny(missing_docs)]
-#![feature(never_type, plugin, struct_field_attributes, fn_traits, unboxed_closures)]
+#![feature(fn_traits, move_cell, never_type, plugin, struct_field_attributes, unboxed_closures)]
 #![plugin(tarpc_plugins)]
 
 extern crate byteorder;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1040,6 +1040,25 @@ mod functional_test {
         }
 
         #[test]
+        fn no_shutdown() {
+            use client;
+            use client::sync::ClientExt;
+
+            let _ = env_logger::init();
+            let (addr, mut client, shutdown) =
+                unwrap!(start_server_with_sync_client::<SyncClient, Server>(Server));
+            assert_eq!(3, client.add(1, 2).unwrap());
+            assert_eq!("Hey, Tim.", client.hey("Tim".to_string()).unwrap());
+
+            drop(shutdown);
+
+            // Existing clients are served.
+            assert_eq!(3, client.add(1, 2).unwrap());
+            // New connections are accepted.
+            assert!(SyncClient::connect(addr, client::Options::default()).is_ok());
+        }
+
+        #[test]
         fn other_service() {
             let _ = env_logger::init();
             let (_, mut client, _) =

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1023,20 +1023,16 @@ mod functional_test {
 
         #[test]
         fn shutdown() {
-            use client;
-            use client::sync::ClientExt;
-
             let _ = env_logger::init();
-            let (addr, mut client, shutdown) =
+            let (_, mut client, shutdown) =
                 unwrap!(start_server_with_sync_client::<SyncClient, Server>(Server));
             assert_eq!(3, client.add(1, 2).unwrap());
             assert_eq!("Hey, Tim.", client.hey("Tim".to_string()).unwrap());
 
             shutdown.shutdown();
-            // Existing clients are served.
-            assert_eq!(3, client.add(1, 2).unwrap());
-            // New connections are not accepted.
-            assert!(SyncClient::connect(addr, client::Options::default()).is_err());
+            // Existing connections are not honored.
+            let e = client.add(1, 2).err().unwrap();
+            debug!("(Success) shutdown caused client err: {}", e);
         }
 
         #[test]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1016,7 +1016,7 @@ mod functional_test {
         fn simple() {
             let _ = env_logger::init();
             let (_, mut client, _) = unwrap!(start_server_with_sync_client::<SyncClient,
-                                                                          Server>(Server));
+                                                                             Server>(Server));
             assert_eq!(3, client.add(1, 2).unwrap());
             assert_eq!("Hey, Tim.", client.hey("Tim".to_string()).unwrap());
         }
@@ -1141,15 +1141,13 @@ mod functional_test {
             reactor.handle().spawn(server);
 
             let client = FutureClient::connect(addr,
-                                               client::Options::default()
-                                                   .handle(reactor.handle()));
+                                               client::Options::default().handle(reactor.handle()));
             let client = unwrap!(reactor.run(client));
             assert_eq!(reactor.run(client.add(1, 2)).unwrap(), 3);
             drop(client);
 
             let client = FutureClient::connect(addr,
-                                               client::Options::default()
-                                                   .handle(reactor.handle()));
+                                               client::Options::default().handle(reactor.handle()));
             let client = unwrap!(reactor.run(client));
             assert_eq!(reactor.run(client.add(1, 2)).unwrap(), 3);
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -156,11 +156,21 @@ pub struct Shutdown {
 }
 
 impl Shutdown {
-    fn is_lameduck(&self) -> bool {
+    /// Returns `true` iff the server has entered lameduck mode, in which existing connections
+    /// are honored but no new connections are accepted.
+    ///
+    /// Returns `true` if the server is completely shutdown, as well.
+    pub fn is_lameduck(&self) -> bool {
         self.lameduck.load(Ordering::SeqCst)
     }
 
-    /// Shuts down the server immediately.
+    /// Initiates an orderly server shutdown.
+    ///
+    /// First, the server enters lameduck mode, in which
+    /// existing connections are honored but no new connections are accepted. Then, once all
+    /// connections are closed, it initates total shutdown.
+    ///
+    /// This fn will not return until the server is completely shut down.
     pub fn shutdown(self) {
         let (tx, rx) = ::std::sync::mpsc::channel();
         if let Err(_) = self.tx.send(tx) {

--- a/src/server.rs
+++ b/src/server.rs
@@ -177,9 +177,9 @@ impl Shutdown {
             info!("Server already shutdown.");
             return;
         }
-        debug!("Waiting for shutdown to complete...");
+        trace!("Waiting for shutdown to complete...");
         match rx.recv() {
-            Ok(()) => debug!("Server shutdown complete."),
+            Ok(()) => trace!("Server shutdown complete."),
             Err(e) => info!("Error in receiving shutdown ack: {}", e),
         }
     }
@@ -197,7 +197,7 @@ impl<S: Service> Service for ConnectionTrackingService<S> {
     type Future = S::Future;
 
     fn call(&self, req: Self::Request) -> Self::Future {
-        debug!("Calling service.");
+        trace!("Calling service.");
         self.service.call(req)
     }
 }
@@ -242,7 +242,7 @@ impl Handle {
               .map_err(|_| warn!("UnboundedReceiver resolved to an Err; can it do that?"))
               .and_then(move |(result, _)| match result {
                   Some(tx) => {
-                          debug!("Got shutdown request.");
+                          trace!("Got shutdown request.");
                           lameduck.store(true, Ordering::SeqCst);
                           shutdown_ack_tx.send(tx).unwrap();
                           future::Either::A(future::ok(()))
@@ -261,7 +261,7 @@ impl Handle {
 
     /// Runs the server on the current thread, blocking indefinitely.
     pub fn run(&mut self) {
-        debug!("Running...");
+        trace!("Running...");
         loop {
             self.reactor.turn(None);
             if self.shutdown.is_lameduck() {

--- a/src/server.rs
+++ b/src/server.rs
@@ -174,7 +174,7 @@ impl Shutdown {
     pub fn shutdown(self) {
         let (tx, rx) = ::std::sync::mpsc::channel();
         if let Err(_) = self.tx.send(tx) {
-            info!("Server already shutdown.");
+            info!("Server already initiated shutdown.");
             return;
         }
         trace!("Waiting for shutdown to complete...");

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,12 +5,13 @@
 
 use bincode;
 use errors::WireError;
-use futures::{Future, Poll, Stream, future, stream};
-use futures::sync::mpsc;
+use futures::{Future, Poll, Stream, future as futures, stream};
+use futures::sync::{mpsc, oneshot};
+use futures::unsync;
 use net2;
 use protocol::Proto;
 use serde::{Deserialize, Serialize};
-use std::cell::{Cell, RefCell};
+use std::cell::Cell;
 use std::io;
 use std::net::SocketAddr;
 use std::rc::Rc;
@@ -36,30 +37,30 @@ enum Acceptor {
 }
 
 #[cfg(feature = "tls")]
-type Accept = future::Either<future::MapErr<future::Map<AcceptAsync<TcpStream>,
-                                                        fn(TlsStream<TcpStream>) -> StreamType>,
-                                            fn(native_tls::Error) -> io::Error>,
-                             future::FutureResult<StreamType, io::Error>>;
+type Accept = futures::Either<futures::MapErr<futures::Map<AcceptAsync<TcpStream>,
+                                                           fn(TlsStream<TcpStream>) -> StreamType>,
+                                              fn(native_tls::Error) -> io::Error>,
+                              futures::FutureResult<StreamType, io::Error>>;
 
 #[cfg(not(feature = "tls"))]
-type Accept = future::FutureResult<TcpStream, io::Error>;
+type Accept = futures::FutureResult<TcpStream, io::Error>;
 
 impl Acceptor {
     #[cfg(feature = "tls")]
     fn accept(&self, socket: TcpStream) -> Accept {
         match *self {
             Acceptor::Tls(ref tls_acceptor) => {
-                future::Either::A(tls_acceptor.accept_async(socket)
+                futures::Either::A(tls_acceptor.accept_async(socket)
                     .map(StreamType::Tls as _)
                     .map_err(native_to_io))
             }
-            Acceptor::Tcp => future::Either::B(future::ok(StreamType::Tcp(socket))),
+            Acceptor::Tcp => futures::Either::B(futures::ok(StreamType::Tcp(socket))),
         }
     }
 
     #[cfg(not(feature = "tls"))]
     fn accept(&self, socket: TcpStream) -> Accept {
-        future::ok(socket)
+        futures::ok(socket)
     }
 }
 
@@ -122,35 +123,25 @@ impl Options {
 #[doc(hidden)]
 pub type Response<T, E> = Result<T, WireError<E>>;
 
-#[doc(hidden)]
-pub fn listen<S, Req, Resp, E>(new_service: S,
-                               addr: SocketAddr,
-                               handle: &reactor::Handle,
-                               options: Options)
-                               -> io::Result<(SocketAddr, Listen<S, Req, Resp, E>)>
-    where S: NewService<Request = Result<Req, bincode::Error>,
-                        Response = Response<Resp, E>,
-                        Error = io::Error> + 'static,
-          Req: Deserialize + 'static,
-          Resp: Serialize + 'static,
-          E: Serialize + 'static
-{
-    listen_with(new_service, addr, handle, Acceptor::from(options))
-}
-
-/// A handle to a bound server. Must be run to start serving requests.
-#[must_use = "A server does nothing until `run` is called."]
-pub struct Handle {
-    reactor: reactor::Core,
-    addr: SocketAddr,
-    shutdown: Shutdown,
-    server: Box<Future<Item=(), Error=()>>,
-}
-
 /// A hook to shut down a running server.
 #[derive(Clone)]
 pub struct Shutdown {
-    tx: mpsc::UnboundedSender<::std::sync::mpsc::Sender<()>>,
+    tx: mpsc::UnboundedSender<oneshot::Sender<()>>,
+}
+
+/// A future that resolves when server shutdown completes.
+pub struct ShutdownFuture {
+    inner: futures::Either<futures::FutureResult<(), ()>,
+                           futures::OrElse<oneshot::Receiver<()>, Result<(), ()>, AlwaysOk>>,
+}
+
+impl Future for ShutdownFuture {
+    type Item = ();
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<(), ()> {
+        self.inner.poll()
+    }
 }
 
 impl Shutdown {
@@ -161,23 +152,41 @@ impl Shutdown {
     /// connections are closed, it initates total shutdown.
     ///
     /// This fn will not return until the server is completely shut down.
-    pub fn shutdown(self) {
-        let (tx, rx) = ::std::sync::mpsc::channel();
-        if let Err(_) = self.tx.send(tx) {
+    pub fn shutdown(self) -> ShutdownFuture {
+        let (tx, rx) = oneshot::channel();
+        let inner = if let Err(_) = self.tx.send(tx) {
             trace!("Server already initiated shutdown.");
-            return;
-        }
-        trace!("Waiting for shutdown to complete...");
-        match rx.recv() {
-            Ok(()) => trace!("Server shutdown complete."),
-            Err(_) => trace!("Server already initiated shutdown."),
-        }
+            futures::Either::A(futures::ok(()))
+        } else {
+            futures::Either::B(rx.or_else(AlwaysOk))
+        };
+        ShutdownFuture { inner: inner }
+    }
+}
+
+enum ConnectionAction {
+    Increment,
+    Decrement,
+}
+
+#[derive(Clone)]
+struct ConnectionTracker {
+    tx: unsync::mpsc::UnboundedSender<ConnectionAction>,
+}
+
+impl ConnectionTracker {
+    fn increment(&self) {
+        let _ = self.tx.send(ConnectionAction::Increment);
+    }
+
+    fn decrement(&self) {
+        let _ = self.tx.send(ConnectionAction::Decrement);
     }
 }
 
 struct ConnectionTrackingService<S> {
     service: S,
-    tx: mpsc::UnboundedSender<ConnectionAction>,
+    tracker: ConnectionTracker,
 }
 
 impl<S: Service> Service for ConnectionTrackingService<S> {
@@ -192,99 +201,322 @@ impl<S: Service> Service for ConnectionTrackingService<S> {
     }
 }
 
+struct ConnectionTrackingNewService<S> {
+    new_service: S,
+    connection_tracker: ConnectionTracker,
+}
+
+impl<S: NewService> NewService for ConnectionTrackingNewService<S> {
+    type Request = S::Request;
+    type Response = S::Response;
+    type Error = S::Error;
+    type Instance = ConnectionTrackingService<S::Instance>;
+
+    fn new_service(&self) -> io::Result<Self::Instance> {
+        self.connection_tracker.increment();
+        Ok(ConnectionTrackingService {
+            service: self.new_service.new_service()?,
+            tracker: self.connection_tracker.clone(),
+        })
+    }
+}
+
 impl<S> Drop for ConnectionTrackingService<S> {
     fn drop(&mut self) {
-        let _ = self.tx.send(ConnectionAction::Dec);
+        self.tracker.decrement();
     }
 }
 
-enum ConnectionAction { Inc, Dec, }
+/// Future-specific server utilities.
+pub mod future {
+    pub use super::*;
 
-
-impl Handle {
-    #[doc(hidden)]
-    pub fn listen<S, Req, Resp, E>(new_service: S,
-                                   addr: SocketAddr,
-                                   options: Options)
-                                   -> io::Result<Self>
-        where S: NewService<Request = Result<Req, bincode::Error>,
-                            Response = Response<Resp, E>,
-                            Error = io::Error> + 'static,
-              Req: Deserialize + 'static,
-              Resp: Serialize + 'static,
-              E: Serialize + 'static
-    {
-        let reactor = reactor::Core::new()?;
-
-        let (shutdown_tx, shutdown_rx) = mpsc::unbounded::<::std::sync::mpsc::Sender<()>>();
-        let (connection_tx, connection_rx) = mpsc::unbounded();
-        let shutdown = Rc::new(RefCell::new(None));
-        let connections = Rc::new(Cell::new(0));
-
-        let (addr, server) = {
-            let tx = connection_tx.clone();
-            listen(move || {
-                let _ = tx.send(ConnectionAction::Inc);
-                Ok(ConnectionTrackingService {
-                    service: new_service.new_service()?,
-                    tx: tx.clone(),
-                })
-            }, addr, &reactor.handle(), options)?
-        };
-        let shutdown2 = shutdown.clone();
-        let connections2 = connections.clone();
-        let shutdown = {
-            shutdown_rx
-                .take(1)
-                .map(move |tx| {
-                    debug!("Received shutdown request.");
-                    *shutdown.borrow_mut() = Some(tx)
-                })
-                .merge(connection_rx.map(move |action| {
-                    match action {
-                        ConnectionAction::Inc => connections.set(connections.get() + 1),
-                        ConnectionAction::Dec => connections.set(connections.get() - 1),
-                    }
-                    trace!("Open connections: {}", connections.get());
-                }))
-                .take_while(move |_| {
-                    let shutdown = shutdown2.borrow();
-                    let should_continue = shutdown.is_none() || connections2.get() > 0;
-                    if !should_continue {
-                        debug!("Shutting down.");
-                        if let Some(ref shutdown) = *shutdown {
-                            let _ = shutdown.send(());
-                        }
-                    }
-                    Ok(should_continue)
-                })
-                .map_err(|_| warn!("UnboundedReceiver resolved to an Err; can it do that?"))
-                .for_each(|_| Ok(()))
-        };
-        let server = Box::new(server.select(shutdown).then(|_| Ok(())));
-        let shutdown = Shutdown { tx: shutdown_tx };
-        Ok(Handle { reactor, addr, shutdown, server, })
+    /// A handle to a bound server.
+    pub struct Handle {
+        addr: SocketAddr,
+        shutdown: Shutdown,
     }
 
-    /// Runs the server on the current thread, blocking indefinitely.
-    pub fn run(mut self) {
-        trace!("Running...");
-        match self.reactor.run(self.server) {
-            Ok(()) => debug!("Server successfully shutdown."),
-            Err(()) => debug!("Server shutdown due to error."),
+    impl Handle {
+        #[doc(hidden)]
+        pub fn listen<S, Req, Resp, E>(new_service: S,
+                                       addr: SocketAddr,
+                                       handle: &reactor::Handle,
+                                       options: Options)
+                                       -> io::Result<(Self, Listen<S, Req, Resp, E>)>
+            where S: NewService<Request = Result<Req, bincode::Error>,
+                                Response = Response<Resp, E>,
+                                Error = io::Error> + 'static,
+                  Req: Deserialize + 'static,
+                  Resp: Serialize + 'static,
+                  E: Serialize + 'static
+        {
+            let (addr, shutdown, server) =
+                listen_with(new_service, addr, handle, Acceptor::from(options))?;
+            Ok((Handle {
+                    addr: addr,
+                    shutdown: shutdown,
+                },
+                server))
+        }
+
+        /// Returns a hook for shutting down the server.
+        pub fn shutdown(&self) -> &Shutdown {
+            &self.shutdown
+        }
+
+        /// The socket address the server is bound to.
+        pub fn addr(&self) -> SocketAddr {
+            self.addr
         }
     }
+}
 
-    /// Returns a hook for shutting down the server.
-    pub fn shutdown(&self) -> Shutdown {
-        self.shutdown.clone()
+/// Sync-specific server utilities.
+pub mod sync {
+    pub use super::*;
+
+    /// A handle to a bound server. Must be run to start serving requests.
+    #[must_use = "A server does nothing until `run` is called."]
+    pub struct Handle {
+        reactor: reactor::Core,
+        handle: future::Handle,
+        server: Box<Future<Item = (), Error = ()>>,
     }
 
-    /// The socket address the server is bound to.
-    pub fn addr(&self) -> SocketAddr {
-        self.addr
+    impl Handle {
+        #[doc(hidden)]
+        pub fn listen<S, Req, Resp, E>(new_service: S,
+                                       addr: SocketAddr,
+                                       options: Options)
+                                       -> io::Result<Self>
+            where S: NewService<Request = Result<Req, bincode::Error>,
+                                Response = Response<Resp, E>,
+                                Error = io::Error> + 'static,
+                  Req: Deserialize + 'static,
+                  Resp: Serialize + 'static,
+                  E: Serialize + 'static
+        {
+            let reactor = reactor::Core::new()?;
+            let (handle, server) =
+                future::Handle::listen(new_service, addr, &reactor.handle(), options)?;
+            let server = Box::new(server);
+            Ok(Handle {
+                reactor: reactor,
+                handle: handle,
+                server: server,
+            })
+        }
+
+        /// Runs the server on the current thread, blocking indefinitely.
+        pub fn run(mut self) {
+            trace!("Running...");
+            match self.reactor.run(self.server) {
+                Ok(()) => debug!("Server successfully shutdown."),
+                Err(()) => debug!("Server shutdown due to error."),
+            }
+        }
+
+        /// Returns a hook for shutting down the server.
+        pub fn shutdown(&self) -> &Shutdown {
+            self.handle.shutdown()
+        }
+
+        /// The socket address the server is bound to.
+        pub fn addr(&self) -> SocketAddr {
+            self.handle.addr()
+        }
     }
 }
+
+struct ShutdownSetter {
+    shutdown: Rc<Cell<Option<oneshot::Sender<()>>>>,
+}
+
+impl FnOnce<(oneshot::Sender<()>,)> for ShutdownSetter {
+    type Output = ();
+
+    extern "rust-call" fn call_once(self, tx: (oneshot::Sender<()>,)) {
+        self.call(tx);
+    }
+}
+
+impl FnMut<(oneshot::Sender<()>,)> for ShutdownSetter {
+    extern "rust-call" fn call_mut(&mut self, tx: (oneshot::Sender<()>,)) {
+        self.call(tx);
+    }
+}
+
+impl Fn<(oneshot::Sender<()>,)> for ShutdownSetter {
+    extern "rust-call" fn call(&self, (tx,): (oneshot::Sender<()>,)) {
+        debug!("Received shutdown request.");
+        self.shutdown.set(Some(tx));
+    }
+}
+
+struct ConnectionWatcher {
+    connections: Rc<Cell<u64>>,
+}
+
+impl FnOnce<(ConnectionAction,)> for ConnectionWatcher {
+    type Output = ();
+
+    extern "rust-call" fn call_once(self, action: (ConnectionAction,)) {
+        self.call(action);
+    }
+}
+
+impl FnMut<(ConnectionAction,)> for ConnectionWatcher {
+    extern "rust-call" fn call_mut(&mut self, action: (ConnectionAction,)) {
+        self.call(action);
+    }
+}
+
+impl Fn<(ConnectionAction,)> for ConnectionWatcher {
+    extern "rust-call" fn call(&self, (action,): (ConnectionAction,)) {
+        match action {
+            ConnectionAction::Increment => self.connections.set(self.connections.get() + 1),
+            ConnectionAction::Decrement => self.connections.set(self.connections.get() - 1),
+        }
+        trace!("Open connections: {}", self.connections.get());
+    }
+}
+
+struct ShutdownPredicate {
+    shutdown: Rc<Cell<Option<oneshot::Sender<()>>>>,
+    connections: Rc<Cell<u64>>,
+}
+
+impl<T> FnOnce<T> for ShutdownPredicate {
+    type Output = Result<bool, ()>;
+
+    extern "rust-call" fn call_once(self, arg: T) -> Self::Output {
+        self.call(arg)
+    }
+}
+
+impl<T> FnMut<T> for ShutdownPredicate {
+    extern "rust-call" fn call_mut(&mut self, arg: T) -> Self::Output {
+        self.call(arg)
+    }
+}
+
+impl<T> Fn<T> for ShutdownPredicate {
+    extern "rust-call" fn call(&self, _: T) -> Self::Output {
+        match self.shutdown.take() {
+            Some(shutdown) => {
+                if self.connections.get() == 0 {
+                    debug!("Shutting down.");
+                    let _ = shutdown.complete(());
+                    Ok(false)
+                } else {
+                    self.shutdown.set(Some(shutdown));
+                    Ok(true)
+                }
+            }
+            None => Ok(true),
+        }
+    }
+}
+
+struct Warn(&'static str);
+
+impl<T> FnOnce<T> for Warn {
+    type Output = ();
+
+    extern "rust-call" fn call_once(self, arg: T) -> Self::Output {
+        self.call(arg)
+    }
+}
+
+impl<T> FnMut<T> for Warn {
+    extern "rust-call" fn call_mut(&mut self, arg: T) -> Self::Output {
+        self.call(arg)
+    }
+}
+
+impl<T> Fn<T> for Warn {
+    extern "rust-call" fn call(&self, _: T) -> Self::Output {
+        warn!("{}", self.0)
+    }
+}
+
+struct AlwaysOk;
+
+impl<T> FnOnce<T> for AlwaysOk {
+    type Output = Result<(), ()>;
+
+    extern "rust-call" fn call_once(self, arg: T) -> Self::Output {
+        self.call(arg)
+    }
+}
+
+impl<T> FnMut<T> for AlwaysOk {
+    extern "rust-call" fn call_mut(&mut self, arg: T) -> Self::Output {
+        self.call(arg)
+    }
+}
+
+impl<T> Fn<T> for AlwaysOk {
+    extern "rust-call" fn call(&self, _: T) -> Self::Output {
+        Ok(())
+    }
+}
+
+type ShutdownStream = stream::Map<stream::Take<mpsc::UnboundedReceiver<oneshot::Sender<()>>>,
+                                  ShutdownSetter>;
+
+type ConnectionStream = stream::Map<unsync::mpsc::UnboundedReceiver<ConnectionAction>,
+                                    ConnectionWatcher>;
+
+struct ShutdownWatcher {
+    inner: stream::ForEach<stream::MapErr<stream::TakeWhile<stream::Merge<ShutdownStream,
+                                                                          ConnectionStream>,
+                                                            ShutdownPredicate,
+                                                            Result<bool, ()>>,
+                                          Warn>,
+                           AlwaysOk,
+                           Result<(), ()>>,
+}
+
+impl Future for ShutdownWatcher {
+    type Item = ();
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<(), ()> {
+        self.inner.poll()
+    }
+}
+
+/// Creates a future that completes when a shutdown is signaled and no connections are open.
+fn shutdown_watcher() -> (ConnectionTracker, Shutdown, ShutdownWatcher) {
+    let (shutdown_tx, shutdown_rx) = mpsc::unbounded::<oneshot::Sender<()>>();
+    let (connection_tx, connection_rx) = unsync::mpsc::unbounded();
+    let shutdown = Rc::new(Cell::new(None));
+    let connections = Rc::new(Cell::new(0));
+    let shutdown2 = shutdown.clone();
+    let connections2 = connections.clone();
+
+    let inner = shutdown_rx.take(1)
+        .map(ShutdownSetter { shutdown: shutdown })
+        .merge(connection_rx.map(ConnectionWatcher { connections: connections }))
+        .take_while(ShutdownPredicate {
+            shutdown: shutdown2,
+            connections: connections2,
+        })
+        .map_err(Warn("UnboundedReceiver resolved to an Err; can it do that?"))
+        .for_each(AlwaysOk);
+
+    (ConnectionTracker { tx: connection_tx },
+     Shutdown { tx: shutdown_tx },
+     ShutdownWatcher { inner: inner })
+}
+
+type AcceptStream = stream::AndThen<Incoming, Acceptor, Accept>;
+
+type BindStream<S> = stream::ForEach<AcceptStream,
+                                     Bind<ConnectionTrackingNewService<S>>,
+                                     io::Result<()>>;
 
 /// The future representing a running server.
 #[doc(hidden)]
@@ -296,10 +528,10 @@ pub struct Listen<S, Req, Resp, E>
           Resp: Serialize + 'static,
           E: Serialize + 'static
 {
-    inner: future::MapErr<stream::ForEach<stream::AndThen<Incoming, Acceptor, Accept>,
-                                          Bind<S>,
-                                          io::Result<()>>,
-                          fn(io::Error)>,
+    inner: futures::Then<futures::Select<futures::MapErr<BindStream<S>, fn(io::Error)>,
+                                         ShutdownWatcher>,
+                         Result<(), ()>,
+                         AlwaysOk>,
 }
 
 impl<S, Req, Resp, E> Future for Listen<S, Req, Resp, E>
@@ -323,7 +555,7 @@ fn listen_with<S, Req, Resp, E>(new_service: S,
                                 addr: SocketAddr,
                                 handle: &reactor::Handle,
                                 acceptor: Acceptor)
-                                -> io::Result<(SocketAddr, Listen<S, Req, Resp, E>)>
+                                -> io::Result<(SocketAddr, Shutdown, Listen<S, Req, Resp, E>)>
     where S: NewService<Request = Result<Req, bincode::Error>,
                         Response = Response<Resp, E>,
                         Error = io::Error> + 'static,
@@ -337,14 +569,20 @@ fn listen_with<S, Req, Resp, E>(new_service: S,
 
     let handle = handle.clone();
 
-    let inner = listener.incoming()
+    let (connection_tracker, shutdown, shutdown_future) = shutdown_watcher();
+    let server = listener.incoming()
         .and_then(acceptor)
         .for_each(Bind {
             handle: handle,
-            new_service: new_service,
+            new_service: ConnectionTrackingNewService {
+                connection_tracker: connection_tracker,
+                new_service: new_service,
+            },
         })
         .map_err(log_err as _);
-    Ok((addr, Listen { inner: inner }))
+
+    let server = server.select(shutdown_future).then(AlwaysOk);
+    Ok((addr, shutdown, Listen { inner: server }))
 }
 
 fn log_err(e: io::Error) {

--- a/src/server.rs
+++ b/src/server.rs
@@ -170,7 +170,7 @@ impl Shutdown {
         trace!("Waiting for shutdown to complete...");
         match rx.recv() {
             Ok(()) => trace!("Server shutdown complete."),
-            Err(e) => trace!("Server already initiated shutdown."),
+            Err(_) => trace!("Server already initiated shutdown."),
         }
     }
 }
@@ -245,6 +245,7 @@ impl Handle {
                         ConnectionAction::Inc => connections.set(connections.get() + 1),
                         ConnectionAction::Dec => connections.set(connections.get() - 1),
                     }
+                    trace!("Open connections: {}", connections.get());
                 }))
                 .take_while(move |_| {
                     let shutdown = shutdown2.borrow();


### PR DESCRIPTION
Fixes #62 

Edit: as @jonhoo pointed out, this doesn't actually allow `run` to return right now. It just sends servers into lame duck mode, where they honor existing connections but don't accept new ones.

Edit 2: the server now shuts down after all pre-lameduck connections are closed.

Edit 3: changed to two handles: `server::sync::Handle` and `server::future::Handle`. The future one has `addr()` and `shutdown()` and the sync one has those plus `run()`.