### PR TITLE
Fix vulnerability.

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -87,6 +87,13 @@ macro_rules! impl_deserialize {
                                 -> ::std::result::Result<impl_deserialize_Field__, E>
                                 where E: $crate::serde::de::Error,
                             {
+                                if impl_deserialize_value__ == 0 {
+                                    return ::std::result::Result::Err(
+                                        $crate::serde::de::Error::custom(
+                                            "Variant 0 is a sentinel value and should not \
+                                            be serialized!"));
+                                }
+
                                 $(
                                     if impl_deserialize_value__ == $n {
                                         return ::std::result::Result::Ok(


### PR DESCRIPTION
0 is a sentinel value used to make all enums refutable. This is a hack around issues in maros
where you're unknowingly treating irrefutable patterns as refutable, which is unfortunately
a hard error.

The server panics if it ever encountered the 0-variant, which before this patch was possible. Now,
it's not possible, because 0-variants are now not able to be deserialized.