### PR TITLE
bincode 1.0.0-alpha6 changed `SizeLimit` to a trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ description = "An RPC framework for Rust with a focus on ease of use."
 travis-ci = { repository = "google/tarpc" }
 
 [dependencies]
-bincode = "1.0.0-alpha4"
+bincode = "1.0.0-alpha6"
 byteorder = "1.0"
 cfg-if = "0.1.0"
 futures = "0.1.7"

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@
 // This file may not be copied, modified, or distributed except according to those terms.
 
 use {serde, tokio_core};
-use bincode::{self, SizeLimit};
+use bincode::{self, Infinite};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use std::io::{self, Cursor};
 use std::marker::PhantomData;
@@ -47,7 +47,7 @@ impl<Encode, Decode> tokio_core::io::Codec for Codec<Encode, Decode>
         buf.write_u64::<BigEndian>(bincode::serialized_size(&message)).unwrap();
         bincode::serialize_into(buf,
                                 &message,
-                                SizeLimit::Infinite)
+                                Infinite)
             .map_err(|serialize_err| io::Error::new(io::ErrorKind::Other, serialize_err))?;
         trace!("Encoded buffer: {:?}", buf);
         Ok(())
@@ -91,7 +91,7 @@ impl<Encode, Decode> tokio_core::io::Codec for Codec<Encode, Decode>
                 Payload { id, len } => {
                     let payload = buf.drain_to(len as usize);
                     let result = bincode::deserialize_from(&mut Cursor::new(payload),
-                                                           SizeLimit::Infinite);
+                                                           Infinite);
                     // Reset the state machine because, either way, we're done processing this
                     // message.
                     self.state = Id;


### PR DESCRIPTION
Unfortunately, cargo's semantic versioning gets confused by the `-alpha` suffix in current bincode versions (I think): even though tarpc's Cargo.toml specified version `1.0.0-alpha4`, `cargo` will download the more recent `1.0.0-alpha6`, which has breaking changes to the `SizeLimit` enum.

This change makes tarpc work with bincode 1.0.0-alpha6 and updates the dependency.

Fixes #133 for me.