### PR TITLE
Fix breakage caused by nightly compiler changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tarpc"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Adam Wright <adam.austin.wright@gmail.com>", "Tim Kuehn <timothy.j.kuehn@gmail.com>"]
 license = "MIT"
 documentation = "https://docs.rs/tarpc"
@@ -26,7 +26,7 @@ net2 = "0.2"
 num_cpus = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
-tarpc-plugins = { path = "src/plugins", version = "0.1.1" }
+tarpc-plugins = { path = "src/plugins", version = "0.2.0" }
 thread-pool = "0.1.1"
 tokio-core = "0.1.6"
 tokio-io = "0.1"

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ arguments to tarpc fns.
 Add to your `Cargo.toml` dependencies:
 
 ```toml
-tarpc = "0.8.0"
-tarpc-plugins = "0.1.1"
+tarpc = "0.9.0"
+tarpc-plugins = "0.2.0"
 ```
 
 ## Example: Sync

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,8 @@
+## 0.9.0 (2017-09-17)
+
+## Breaking Changes
+Updates tarpc to use tarpc-plugins 0.2.
+
 ## 0.8.0 (2017-05-05)
 
 ## Breaking Changes

--- a/examples/readme_errors.rs
+++ b/examples/readme_errors.rs
@@ -6,12 +6,10 @@
 #![feature(plugin, use_extern_macros)]
 #![plugin(tarpc_plugins)]
 
-extern crate futures;
 #[macro_use]
 extern crate tarpc;
 #[macro_use]
 extern crate serde_derive;
-extern crate tokio_core;
 
 use std::error::Error;
 use std::fmt;

--- a/examples/readme_sync.rs
+++ b/examples/readme_sync.rs
@@ -7,10 +7,8 @@
 #![feature(plugin, use_extern_macros)]
 #![plugin(tarpc_plugins)]
 
-extern crate futures;
 #[macro_use]
 extern crate tarpc;
-extern crate tokio_core;
 
 use std::sync::mpsc;
 use std::thread;

--- a/examples/sync_server_calling_server.rs
+++ b/examples/sync_server_calling_server.rs
@@ -9,8 +9,6 @@
 extern crate env_logger;
 #[macro_use]
 extern crate tarpc;
-extern crate futures;
-extern crate tokio_core;
 
 use add::{SyncService as AddSyncService, SyncServiceExt as AddExt};
 use double::{SyncService as DoubleSyncService, SyncServiceExt as DoubleExt};

--- a/examples/throughput.rs
+++ b/examples/throughput.rs
@@ -11,7 +11,6 @@ extern crate lazy_static;
 #[macro_use]
 extern crate tarpc;
 extern crate env_logger;
-extern crate futures;
 extern crate serde_bytes;
 extern crate tokio_core;
 

--- a/examples/two_clients.rs
+++ b/examples/two_clients.rs
@@ -10,9 +10,7 @@
 extern crate log;
 #[macro_use]
 extern crate tarpc;
-extern crate bincode;
 extern crate env_logger;
-extern crate futures;
 extern crate tokio_core;
 
 use bar::FutureServiceExt as BarExt;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -620,8 +620,7 @@ mod functional_test {
                 if #[cfg(target_os = "macos")] {
                     extern crate security_framework;
 
-                    use self::security_framework::certificate::SecCertificate;
-                    use native_tls_inner::backend::security_framework::TlsConnectorBuilderExt;
+                    use native_tls_inner::Certificate;
 
                     fn get_future_tls_client_options() -> future::client::Options {
                         future::client::Options::default().tls(get_tls_client_context())
@@ -633,9 +632,9 @@ mod functional_test {
 
                     fn get_tls_client_context() -> Context {
                         let buf = include_bytes!("../test/root-ca.der");
-                        let cert = unwrap!(SecCertificate::from_der(buf));
+                        let cert = unwrap!(Certificate::from_der(buf));
                         let mut connector = unwrap!(TlsConnector::builder());
-                        connector.anchor_certificates(&[cert]);
+                        connector.add_root_certificate(cert);
 
                         Context {
                             domain: DOMAIN.into(),

--- a/src/plugins/Cargo.toml
+++ b/src/plugins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tarpc-plugins"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Adam Wright <adam.austin.wright@gmail.com>", "Tim Kuehn <timothy.j.kuehn@gmail.com>"]
 license = "MIT"
 documentation = "https://docs.rs/tarpc"

--- a/src/plugins/src/lib.rs
+++ b/src/plugins/src/lib.rs
@@ -65,7 +65,7 @@ fn snake_to_camel(cx: &mut ExtCtxt, sp: Span, tts: &[TokenTree]) -> Box<MacResul
             if let Some(tt @ TokenTree::Token(_, token::Eq)) = tokens.next() {
                 let mut docstr = tokens.next().expect("Docstrings must have literal docstring");
                 if let TokenTree::Token(_, token::Literal(token::Str_(ref mut doc), _)) = docstr {
-                    *doc = Symbol::intern(&str_lit(&doc.as_str()).replace("{}", &old_ident));
+                    *doc = Symbol::intern(&str_lit(&doc.as_str(), None).replace("{}", &old_ident));
                 } else {
                     unreachable!();
                 }


### PR DESCRIPTION
Also a couple other things:

* Replaced a deprecated TLS method call with the new version.
* Removed unused imports from some examples.
* Bump version numbers.

Fixes #166