### PR TITLE
Update regex to match diffs output by cargo fmt.

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -96,7 +96,7 @@ do
         diff="$diff$(cargo fmt -- --skip-children --write-mode=diff $file)"
 	fi
 done
-if grep --quiet "^Diff at line" <<< "$diff"; then
+if grep --quiet "^[-+]" <<< "$diff"; then
     FMTRESULT=1
 fi
 


### PR DESCRIPTION
It appears the header of the diffs output by cargo fmt have changed. It now says "Diff in /blah/blah/blah.rs at line 99:" Matching on lines starting with + or - should be more future-proof against changes to the surroundings.