### PR TITLE
Don't panic in pump_write when a client is dropped and there are more calls to poll.

### DIFF
--- a/bincode-transport/Cargo.toml
+++ b/bincode-transport/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 description = "A bincode-based transport for tarpc services."
 
 [dependencies]
-bincode = { version = "1.0", features = ["i128"] }
+bincode = "1"
 futures_legacy = { version = "0.1", package = "futures" }
 pin-utils = "0.1.0-alpha.4"
 rpc = { package = "tarpc-lib", version = "0.3", path = "../rpc", features = ["serde1"] }

--- a/tarpc/Cargo.toml
+++ b/tarpc/Cargo.toml
@@ -28,7 +28,7 @@ rpc = { package = "tarpc-lib", path = "../rpc", version = "0.3" }
 futures-preview = "0.3.0-alpha.13"
 
 [dev-dependencies]
-bincode = "1.0"
+bincode = "1"
 bytes = { version = "0.4", features = ["serde"] }
 humantime = "1.0"
 futures-preview = { version = "0.3.0-alpha.13", features = ["compat"] }


### PR DESCRIPTION
This can happen in cases where a response is being read and the client isn't around.

Fixes #220