### PR TITLE
Update to futures-preview 0.3.0-alpha.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For this example, in addition to tarpc, also add two other dependencies to
 your `Cargo.toml`:
 
 ```toml
-futures-preview = { version = "0.3.0-alpha.16", features = ["compat"] }
+futures-preview = { version = "0.3.0-alpha.17", features = ["compat"] }
 tokio = "0.1"
 ```
 

--- a/bincode-transport/Cargo.toml
+++ b/bincode-transport/Cargo.toml
@@ -14,7 +14,7 @@ description = "A bincode-based transport for tarpc services."
 
 [dependencies]
 bincode = "1"
-futures-preview = { version = "0.3.0-alpha.16", features = ["compat"] }
+futures-preview = { version = "0.3.0-alpha.17", features = ["compat"] }
 futures_legacy = { version = "0.1", package = "futures" }
 pin-utils = "0.1.0-alpha.4"
 rpc = { package = "tarpc-lib", version = "0.6", path = "../rpc", features = ["serde1"] }

--- a/bincode-transport/src/lib.rs
+++ b/bincode-transport/src/lib.rs
@@ -60,7 +60,7 @@ where
     S: AsyncWrite,
     SinkItem: Serialize,
 {
-    type SinkError = io::Error;
+    type Error = io::Error;
 
     fn start_send(self: Pin<&mut Self>, item: SinkItem) -> io::Result<()> {
         self.inner()

--- a/bincode-transport/tests/cancel.rs
+++ b/bincode-transport/tests/cancel.rs
@@ -7,6 +7,7 @@
 //! Tests client/server control flow.
 
 #![feature(async_await)]
+#![feature(async_closure)]
 
 use futures::{
     compat::{Executor01CompatExt, Future01CompatExt},

--- a/bincode-transport/tests/pushback.rs
+++ b/bincode-transport/tests/pushback.rs
@@ -7,6 +7,7 @@
 //! Tests client/server control flow.
 
 #![feature(async_await)]
+#![feature(async_closure)]
 
 use futures::{
     compat::{Executor01CompatExt, Future01CompatExt},

--- a/example-service/Cargo.toml
+++ b/example-service/Cargo.toml
@@ -15,7 +15,7 @@ description = "An example server built on tarpc."
 [dependencies]
 bincode-transport = { package = "tarpc-bincode-transport", version = "0.7", path = "../bincode-transport" }
 clap = "2.0"
-futures-preview = { version = "0.3.0-alpha.16", features = ["compat"] }
+futures-preview = { version = "0.3.0-alpha.17", features = ["compat"] }
 serde = { version = "1.0" }
 tarpc = { version = "0.18", path = "../tarpc", features = ["serde1"] }
 tokio = "0.1"

--- a/json-transport/Cargo.toml
+++ b/json-transport/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 description = "A JSON-based transport for tarpc services."
 
 [dependencies]
-futures-preview = { version = "0.3.0-alpha.16", features = ["compat"] }
+futures-preview = { version = "0.3.0-alpha.17", features = ["compat"] }
 futures_legacy = { version = "0.1", package = "futures" }
 pin-utils = "0.1.0-alpha.4"
 rpc = { package = "tarpc-lib", version = "0.6", path = "../rpc", features = ["serde1"] }

--- a/json-transport/src/lib.rs
+++ b/json-transport/src/lib.rs
@@ -67,7 +67,7 @@ where
     S: AsyncWrite,
     SinkItem: Serialize,
 {
-    type SinkError = io::Error;
+    type Error = io::Error;
 
     fn start_send(self: Pin<&mut Self>, item: SinkItem) -> io::Result<()> {
         self.inner()

--- a/json-transport/tests/cancel.rs
+++ b/json-transport/tests/cancel.rs
@@ -7,6 +7,7 @@
 //! Tests client/server control flow.
 
 #![feature(async_await)]
+#![feature(async_closure)]
 
 use futures::{
     compat::{Executor01CompatExt, Future01CompatExt},

--- a/json-transport/tests/pushback.rs
+++ b/json-transport/tests/pushback.rs
@@ -7,6 +7,7 @@
 //! Tests client/server control flow.
 
 #![feature(async_await)]
+#![feature(async_closure)]
 
 use futures::{
     compat::{Executor01CompatExt, Future01CompatExt},

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -18,7 +18,7 @@ serde1 = ["trace/serde", "serde", "serde/derive"]
 
 [dependencies]
 fnv = "1.0"
-futures-preview = { version = "0.3.0-alpha.16", features = ["compat"] }
+futures-preview = { version = "0.3.0-alpha.17", features = ["compat"] }
 humantime = "1.0"
 log = "0.4"
 pin-utils = "0.1.0-alpha.4"
@@ -28,7 +28,7 @@ trace = { package = "tarpc-trace", version = "0.2", path = "../trace" }
 serde = { optional = true, version = "1.0" }
 
 [dev-dependencies]
-futures-test-preview = { version = "0.3.0-alpha.16" }
+futures-test-preview = { version = "0.3.0-alpha.17" }
 env_logger = "0.6"
 tokio = "0.1"
 tokio-executor = "0.1"

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -9,7 +9,8 @@
     integer_atomics,
     try_trait,
     arbitrary_self_types,
-    async_await
+    async_await,
+    async_closure
 )]
 #![deny(missing_docs, missing_debug_implementations)]
 

--- a/rpc/src/server/mod.rs
+++ b/rpc/src/server/mod.rs
@@ -18,7 +18,6 @@ use futures::{
     ready,
     stream::Fuse,
     task::{Context, Poll},
-    try_ready,
 };
 use humantime::format_rfc3339;
 use log::{debug, error, info, trace, warn};
@@ -334,7 +333,7 @@ where
                     peer,
                     self.as_mut().in_flight_requests().len(),
                 );
-                try_ready!(self.as_mut().channel().poll_flush(cx));
+                ready!(self.as_mut().channel().poll_flush(cx)?);
             }
         }
         Poll::Ready(Ok(()))

--- a/rpc/src/transport/channel.rs
+++ b/rpc/src/transport/channel.rs
@@ -51,7 +51,7 @@ impl<Item, SinkItem> Stream for UnboundedChannel<Item, SinkItem> {
 }
 
 impl<Item, SinkItem> Sink<SinkItem> for UnboundedChannel<Item, SinkItem> {
-    type SinkError = io::Error;
+    type Error = io::Error;
 
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         self.tx()
@@ -65,7 +65,7 @@ impl<Item, SinkItem> Sink<SinkItem> for UnboundedChannel<Item, SinkItem> {
             .map_err(|_| io::Error::from(io::ErrorKind::NotConnected))
     }
 
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.tx()
             .poll_flush(cx)
             .map_err(|_| io::Error::from(io::ErrorKind::NotConnected))

--- a/rpc/src/transport/mod.rs
+++ b/rpc/src/transport/mod.rs
@@ -24,7 +24,7 @@ pub mod channel;
 pub trait Transport
 where
     Self: Stream<Item = io::Result<<Self as Transport>::Item>>,
-    Self: Sink<<Self as Transport>::SinkItem, SinkError = io::Error>,
+    Self: Sink<<Self as Transport>::SinkItem, Error = io::Error>,
 {
     /// The type read off the transport.
     type Item;
@@ -45,7 +45,7 @@ pub fn new<S, SinkItem, Item>(
 ) -> impl Transport<Item = Item, SinkItem = SinkItem>
 where
     S: Stream<Item = io::Result<Item>>,
-    S: Sink<SinkItem, SinkError = io::Error>,
+    S: Sink<SinkItem, Error = io::Error>,
 {
     TransportShim {
         inner,
@@ -83,21 +83,21 @@ impl<S, Item> Sink<Item> for TransportShim<S, Item>
 where
     S: Sink<Item>,
 {
-    type SinkError = S::SinkError;
+    type Error = S::Error;
 
-    fn start_send(self: Pin<&mut Self>, item: Item) -> Result<(), S::SinkError> {
+    fn start_send(self: Pin<&mut Self>, item: Item) -> Result<(), S::Error> {
         self.inner().start_send(item)
     }
 
-    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), S::SinkError>> {
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), S::Error>> {
         self.inner().poll_ready(cx)
     }
 
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), S::SinkError>> {
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), S::Error>> {
         self.inner().poll_flush(cx)
     }
 
-    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), S::SinkError>> {
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), S::Error>> {
         self.inner().poll_close(cx)
     }
 }
@@ -106,7 +106,7 @@ impl<S, SinkItem, Item> Transport for TransportShim<S, SinkItem>
 where
     S: Stream + Sink<SinkItem>,
     Self: Stream<Item = io::Result<Item>>,
-    Self: Sink<SinkItem, SinkError = io::Error>,
+    Self: Sink<SinkItem, Error = io::Error>,
 {
     type Item = Item;
     type SinkItem = SinkItem;

--- a/tarpc/Cargo.toml
+++ b/tarpc/Cargo.toml
@@ -19,7 +19,7 @@ serde1 = ["rpc/serde1", "serde", "serde/derive"]
 travis-ci = { repository = "google/tarpc" }
 
 [dependencies]
-futures-preview = { version = "0.3.0-alpha.16", features = ["compat"] }
+futures-preview = { version = "0.3.0-alpha.17", features = ["compat"] }
 log = "0.4"
 serde = { optional = true, version = "1.0" }
 rpc = { package = "tarpc-lib", path = "../rpc", version = "0.6" }


### PR DESCRIPTION
- `try_ready!` macro was removed, rust-lang-nursery/futures-rs#1602
- `Sink::SinkError` was renamed to `Sink::Error`

The test failed because `FnBox` has been removed from std, and libtest outdated, waiting for rust-lang/libtest#19 (Tested locally, all passed)