### PR TITLE
Upgrade json-transport to Tokio 0.2

### DIFF
--- a/example-service/src/server.rs
+++ b/example-service/src/server.rs
@@ -10,7 +10,10 @@ use futures::{
     prelude::*,
 };
 use service::World;
-use std::{io, net::SocketAddr};
+use std::{
+    io,
+    net::{IpAddr, SocketAddr},
+};
 use tarpc::{
     context,
     server::{self, Channel, Handler},
@@ -59,11 +62,12 @@ async fn main() -> io::Result<()> {
         .parse()
         .unwrap_or_else(|e| panic!(r#"--port value "{}" invalid: {}"#, port, e));
 
-    let server_addr = ([0, 0, 0, 0], port).into();
+    let server_addr = (IpAddr::from([0, 0, 0, 0]), port);
 
     // tarpc_json_transport is provided by the associated crate tarpc-json-transport. It makes it easy
     // to start up a serde-powered json serialization strategy over TCP.
-    tarpc_json_transport::listen(&server_addr)?
+    tarpc_json_transport::listen(&server_addr)
+        .await?
         // Ignore accept errors.
         .filter_map(|r| future::ready(r.ok()))
         .map(server::BaseChannel::with_defaults)

--- a/json-transport/Cargo.toml
+++ b/json-transport/Cargo.toml
@@ -13,16 +13,14 @@ readme = "../README.md"
 description = "A JSON-based transport for tarpc services."
 
 [dependencies]
-futures-preview = { version = "0.3.0-alpha.18", features = ["compat"] }
-futures_legacy = { version = "0.1", package = "futures" }
-pin-utils = "0.1.0-alpha.4"
-serde = "1.0"
-serde_json = "1.0"
-tokio = { version = "0.1", default-features = false, features = ["codec"] }
-tokio-io = "0.1"
-tokio-serde-json = "0.2"
-tokio-tcp = "0.1"
+futures-preview = "0.3.0-alpha"
+pin-project = "0.4"
+serde = "1"
+serde_json = "1"
+tokio = { version = "0.2.0-alpha", default-features = false, features = ["codec", "io", "net"] }
+tokio-net = "0.2.0-alpha"
+tokio-serde-json = "0.3"
 
 [dev-dependencies]
-futures-test-preview = { version = "0.3.0-alpha.18" }
+pin-utils = "0.1.0-alpha"
 assert_matches = "1.0"

--- a/json-transport/src/lib.rs
+++ b/json-transport/src/lib.rs
@@ -34,6 +34,7 @@ pub struct Transport<S, Item, SinkItem> {
 
 impl<S, Item, SinkItem> Stream for Transport<S, Item, SinkItem>
 where
+    // TODO: Remove Unpin bound when tokio-rs/tokio#1272 is resolved.
     S: AsyncWrite + AsyncRead + Unpin,
     Item: for<'a> Deserialize<'a>,
 {


### PR DESCRIPTION
I am temporarily using git version of `tokio-serde-json`, until a newer version is released.