### PR TITLE
Allow raw identifiers + fixed naming + place all code generation methods in impl

### DIFF
--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -19,7 +19,7 @@ use syn::{
     ext::IdentExt,
     parenthesized,
     parse::{Parse, ParseStream},
-    parse_macro_input, parse_quote,
+    parse_macro_input, parse_quote, parse_str,
     punctuated::Punctuated,
     token::Comma,
     Attribute, FnArg, Ident, Lit, LitBool, MetaNameValue, Pat, PatType, ReturnType, Token, Type,
@@ -204,8 +204,7 @@ pub fn service(attr: TokenStream, input: TokenStream) -> TokenStream {
             .collect::<Vec<_>>(),
         future_types: &camel_case_fn_names
             .iter()
-            .map(|name| format_ident!("{}Fut", name))
-            .map(|ident| parse_quote!(#ident))
+            .map(|name| parse_str(&format!("{}Fut", name)).unwrap())
             .collect::<Vec<_>>(),
         derive_serialize: derive_serialize.as_ref(),
     }

--- a/plugins/tests/service.rs
+++ b/plugins/tests/service.rs
@@ -34,21 +34,23 @@ fn att_service_trait() {
 fn raw_idents() {
     use futures::future::{ready, Ready};
 
+    type r#yield = String;
+
     #[tarpc::service]
     trait r#trait {
-        async fn r#await(r#struct: String, i: i32) -> (String, i32);
-        async fn r#fn(s: String) -> String;
+        async fn r#await(r#struct: r#yield, r#enum: i32) -> (r#yield, i32);
+        async fn r#fn(r#impl: r#yield) -> r#yield;
         async fn r#async();
     }
 
     impl r#trait for () {
-        type AwaitFut = Ready<(String, i32)>;
-        fn r#await(self, _: context::Context, r#struct: String, r#enum: i32) -> Self::AwaitFut {
+        type AwaitFut = Ready<(r#yield, i32)>;
+        fn r#await(self, _: context::Context, r#struct: r#yield, r#enum: i32) -> Self::AwaitFut {
             ready((r#struct, r#enum))
         }
 
-        type FnFut = Ready<String>;
-        fn r#fn(self, _: context::Context, r#impl: String) -> Self::FnFut {
+        type FnFut = Ready<r#yield>;
+        fn r#fn(self, _: context::Context, r#impl: r#yield) -> Self::FnFut {
             ready(r#impl)
         }
 

--- a/plugins/tests/service.rs
+++ b/plugins/tests/service.rs
@@ -29,6 +29,36 @@ fn att_service_trait() {
     }
 }
 
+#[allow(non_camel_case_types)]
+#[test]
+fn raw_idents() {
+    use futures::future::{ready, Ready};
+
+    #[tarpc::service]
+    trait r#trait {
+        async fn r#await(r#struct: String, i: i32) -> (String, i32);
+        async fn r#fn(s: String) -> String;
+        async fn r#async();
+    }
+
+    impl r#trait for () {
+        type AwaitFut = Ready<(String, i32)>;
+        fn r#await(self, _: context::Context, r#struct: String, r#enum: i32) -> Self::AwaitFut {
+            ready((r#struct, r#enum))
+        }
+
+        type FnFut = Ready<String>;
+        fn r#fn(self, _: context::Context, r#impl: String) -> Self::FnFut {
+            ready(r#impl)
+        }
+
+        type AsyncFut = Ready<()>;
+        fn r#async(self, _: context::Context) -> Self::AsyncFut {
+            ready(())
+        }
+    }
+}
+
 #[test]
 fn syntax() {
     #[tarpc::service]


### PR DESCRIPTION
- Allows to define services using raw identifiers like
```rust
pub mod service {
    #[tarpc::service]
    pub trait r#trait {
        async fn r#fn(x: i32) -> Result<u8, String>;
    }
}
```
- Refactored names
- All code generation methods placed im `impl`