### PR TITLE
expose some structs to be able to use a non-tokio executor

### DIFF
--- a/tarpc/src/rpc/mod.rs
+++ b/tarpc/src/rpc/mod.rs
@@ -28,7 +28,7 @@ pub mod client;
 pub mod context;
 pub mod server;
 pub mod transport;
-pub(crate) mod util;
+pub mod util;
 
 pub use crate::{client::Client, server::Server, trace, transport::sealed::Transport};
 
@@ -86,6 +86,16 @@ pub struct Response<T> {
     pub message: Result<T, ServerError>,
 }
 
+impl<T> Response<T> {
+    /// Construct a new response
+    pub fn new(request_id: u64, message: Result<T, ServerError>) -> Self {
+        Self {
+            request_id,
+            message,
+        }
+    }
+}
+
 /// An error response from a server to a client.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[non_exhaustive]
@@ -103,6 +113,13 @@ pub struct ServerError {
     pub kind: io::ErrorKind,
     /// A message describing more detail about the error that occurred.
     pub detail: Option<String>,
+}
+
+impl ServerError {
+    /// Construct a new server error
+    pub fn new(kind: io::ErrorKind, detail: Option<String>) -> Self {
+        Self { kind, detail }
+    }
 }
 
 impl From<ServerError> for io::Error {

--- a/tarpc/src/rpc/util/mod.rs
+++ b/tarpc/src/rpc/util/mod.rs
@@ -4,6 +4,8 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+//! Provides a utility functions for serde, time and hashmap.
+
 use std::{
     collections::HashMap,
     hash::{BuildHasher, Hash},
@@ -11,7 +13,7 @@ use std::{
 };
 
 #[cfg(feature = "serde")]
-pub mod serde;
+pub(crate) mod serde;
 
 /// Extension trait for [SystemTimes](SystemTime) in the future, i.e. deadlines.
 pub trait TimeUntil {


### PR DESCRIPTION
For Inox(https://github.com/vhdirk/inox/) I'm combing tarpc with the glib executor as opposed to the default tokio executor.

In order to also have deadlines for requests, I needed to fork ```ClientHandler``` in my own project. That requires some changes in tarpc so I can create, for instance, a response struct. See https://github.com/vhdirk/inox/blob/master/inox-gtk/src/webextension/rpc.rs

I'm still working on the client side. That one is harder since tokio's ```TimeOut```s are not compatible with custom executors, but they are used throughout the (generated) client code.
