### PR TITLE
Remove uses of pin_project::project attribute

### DIFF
--- a/tarpc/Cargo.toml
+++ b/tarpc/Cargo.toml
@@ -30,7 +30,7 @@ fnv = "1.0"
 futures = "0.3"
 humantime = "1.0"
 log = "0.4"
-pin-project = "0.4"
+pin-project = "0.4.17"
 rand = "0.7"
 tokio = { version = "0.2", features = ["time"] }
 serde = { optional = true, version = "1.0", features = ["derive"] }
@@ -60,4 +60,3 @@ required-features = ["full"]
 [[example]]
 name = "pubsub"
 required-features = ["full"]
-


### PR DESCRIPTION
pin-project will deprecate the project attribute due to some unfixable
limitations.

Refs: https://github.com/taiki-e/pin-project/issues/225

*Although the deprecation of the project attribute has not been released yet, this PR is submitted in advance to avoid the CI from being broken by deprecated warnings.*