### PR TITLE
Remove `#[derive(Debug)]` from library structs

### DIFF
--- a/tarpc/src/rpc.rs
+++ b/tarpc/src/rpc.rs
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-#![deny(missing_docs, missing_debug_implementations)]
+#![deny(missing_docs)]
 
 //! An RPC framework providing client and server.
 //!

--- a/tarpc/src/rpc.rs
+++ b/tarpc/src/rpc.rs
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-#![deny(missing_docs)]
+#![deny(missing_docs, missing_debug_implementations)]
 
 //! An RPC framework providing client and server.
 //!

--- a/tarpc/src/rpc/client.rs
+++ b/tarpc/src/rpc/client.rs
@@ -8,6 +8,7 @@
 
 use crate::context;
 use futures::prelude::*;
+use std::fmt;
 use std::io;
 
 /// Provides a [`Client`] backed by a transport.
@@ -150,5 +151,11 @@ where
             .unwrap_or_else(move |e| error!("Connection broken: {}", e));
         tokio::spawn(dispatch);
         Ok(self.client)
+    }
+}
+
+impl<C, D> fmt::Debug for NewClient<C, D> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "NewClient")
     }
 }

--- a/tarpc/src/rpc/client.rs
+++ b/tarpc/src/rpc/client.rs
@@ -127,7 +127,6 @@ impl Default for Config {
 
 /// A channel and dispatch pair. The dispatch drives the sending and receiving of requests
 /// and must be polled continuously or spawned.
-#[derive(Debug)]
 pub struct NewClient<C, D> {
     /// The new client.
     pub client: C,

--- a/tarpc/src/rpc/server.rs
+++ b/tarpc/src/rpc/server.rs
@@ -47,6 +47,12 @@ impl<Req, Resp> Default for Server<Req, Resp> {
     }
 }
 
+impl<Req, Resp> fmt::Debug for Server<Req, Resp> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "Server")
+    }
+}
+
 /// Settings that control the behavior of the server.
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -231,6 +237,12 @@ where
                 trace_context.trace_id,
             );
         }
+    }
+}
+
+impl<Req, Resp, T> fmt::Debug for BaseChannel<Req, Resp, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "NewClient {:?}", self)
     }
 }
 
@@ -505,6 +517,12 @@ where
     }
 }
 
+impl<C, S> fmt::Debug for ClientHandler<C, S> where C: Channel, {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "ClientHandler")
+    }
+}
+
 /// A future fulfilling a single client request.
 #[pin_project]
 pub struct RequestHandler<F, R> {
@@ -521,6 +539,12 @@ where
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
         let _ = ready!(self.project().resp.poll(cx));
         Poll::Ready(())
+    }
+}
+
+impl<F, R> fmt::Debug for RequestHandler<F, R> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "RequestHandler")
     }
 }
 
@@ -606,6 +630,12 @@ where
                 }
             }
         }
+    }
+}
+
+impl<F, R> fmt::Debug for Resp<F, R> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "Resp")
     }
 }
 

--- a/tarpc/src/rpc/server.rs
+++ b/tarpc/src/rpc/server.rs
@@ -242,7 +242,7 @@ where
 
 impl<Req, Resp, T> fmt::Debug for BaseChannel<Req, Resp, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "NewClient {:?}", self)
+        write!(f, "BaseChannel")
     }
 }
 

--- a/tarpc/src/rpc/server.rs
+++ b/tarpc/src/rpc/server.rs
@@ -36,7 +36,6 @@ pub use self::{
 };
 
 /// Manages clients, serving multiplexed requests over each connection.
-#[derive(Debug)]
 pub struct Server<Req, Resp> {
     config: Config,
     ghost: PhantomData<(Req, Resp)>,
@@ -167,7 +166,6 @@ where
 
 /// BaseChannel lifts a Transport to a Channel by tracking in-flight requests.
 #[pin_project]
-#[derive(Debug)]
 pub struct BaseChannel<Req, Resp, T> {
     config: Config,
     /// Writes responses to the wire and reads requests off the wire.
@@ -384,7 +382,6 @@ where
 
 /// A running handler serving all requests coming over a channel.
 #[pin_project]
-#[derive(Debug)]
 pub struct ClientHandler<C, S>
 where
     C: Channel,
@@ -510,7 +507,6 @@ where
 
 /// A future fulfilling a single client request.
 #[pin_project]
-#[derive(Debug)]
 pub struct RequestHandler<F, R> {
     #[pin]
     resp: Abortable<Resp<F, R>>,
@@ -529,7 +525,6 @@ where
 }
 
 #[pin_project]
-#[derive(Debug)]
 struct Resp<F, R> {
     state: RespState,
     request_id: u64,

--- a/tarpc/src/rpc/server.rs
+++ b/tarpc/src/rpc/server.rs
@@ -517,7 +517,10 @@ where
     }
 }
 
-impl<C, S> fmt::Debug for ClientHandler<C, S> where C: Channel, {
+impl<C, S> fmt::Debug for ClientHandler<C, S>
+where
+    C: Channel,
+{
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "ClientHandler")
     }


### PR DESCRIPTION
Fixes #326.