### PR TITLE
Reduce required tokio features

### DIFF
--- a/example-service/Cargo.toml
+++ b/example-service/Cargo.toml
@@ -17,7 +17,7 @@ clap = "2.33"
 env_logger = "0.8"
 futures = "0.3"
 serde = { version = "1.0" }
-tarpc = { version = "0.25", path = "../tarpc", features = ["full"] }
+tarpc = { path = "../tarpc", features = ["full"] }
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
 
 [lib]

--- a/example-service/Cargo.toml
+++ b/example-service/Cargo.toml
@@ -18,7 +18,7 @@ env_logger = "0.8"
 futures = "0.3"
 serde = { version = "1.0" }
 tarpc = { version = "0.25", path = "../tarpc", features = ["full"] }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
 
 [lib]
 name = "service"


### PR DESCRIPTION
Current example fails to build with minimal set of required tokio features, i.e. `features = ["macros", "net", "rt-multi-thread"]` because tokio tests are not behind a `cfg(test)` gate. For some reason this issue appeared for me after I tried to upgrade tarpc 0.24.1 -> 0.25 dependency. The pr so far consists of 3 commits:

1. All of the `tokio::test`-s are moved inside a `#[cfg(test) mod test { .. }`. This commit is kinda big, maybe it's better to make it smaller with adding a cfg for each test instead.
2. Reduces tokio features for example-service.
3. This one removes a version part of tarpc dependency of example-service, otherwise it fetches from crates-io. I'm not sure how it worked before, perhaps this one is not really needed.