### PR TITLE
Do not enable tokio-serde/json by default

### DIFF
--- a/example-service/Cargo.toml
+++ b/example-service/Cargo.toml
@@ -19,6 +19,7 @@ futures = "0.3"
 serde = { version = "1.0" }
 tarpc = { path = "../tarpc", features = ["full"] }
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
+tokio-serde = { version = "0.8", features = ["json"] }
 
 [lib]
 name = "service"

--- a/tarpc/Cargo.toml
+++ b/tarpc/Cargo.toml
@@ -17,7 +17,7 @@ default = []
 
 serde1 = ["tarpc-plugins/serde1", "serde", "serde/derive"]
 tokio1 = ["tokio/rt-multi-thread"]
-serde-transport = ["serde1", "tokio1", "tokio-serde/json", "tokio-util/codec"]
+serde-transport = ["serde1", "tokio1", "tokio-serde", "tokio-util/codec"]
 tcp = ["tokio/net"]
 
 full = ["serde1", "tokio1", "serde-transport", "tcp"]


### PR DESCRIPTION
By having `tokio-serde/json` forces users that want to use `bincode` only, to have extra dependencies.

After this commit, users need to specify the format they are interested in their Cargo.toml.