### PR TITLE
add serde-transport-json feature flag

### DIFF
--- a/example-service/Cargo.toml
+++ b/example-service/Cargo.toml
@@ -20,10 +20,8 @@ futures = "0.3"
 opentelemetry = { version = "0.13", features = ["rt-tokio"] }
 opentelemetry-jaeger = { version = "0.12", features = ["tokio"] }
 rand = "0.8"
-serde = { version = "1.0" }
 tarpc = { version = "0.26", path = "../tarpc", features = ["full"] }
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
-tokio-serde = { version = "0.8", features = ["json"] }
 tracing = { version = "0.1" }
 tracing-opentelemetry = "0.12"
 tracing-subscriber = "0.2"

--- a/tarpc/Cargo.toml
+++ b/tarpc/Cargo.toml
@@ -18,9 +18,10 @@ default = []
 serde1 = ["tarpc-plugins/serde1", "serde", "serde/derive"]
 tokio1 = ["tokio/rt-multi-thread"]
 serde-transport = ["serde1", "tokio1", "tokio-serde", "tokio-util/codec"]
+serde-transport-json = ["tokio-serde/json"]
 tcp = ["tokio/net"]
 
-full = ["serde1", "tokio1", "serde-transport", "tcp"]
+full = ["serde1", "tokio1", "serde-transport", "serde-transport-json", "tcp"]
 
 [badges]
 travis-ci = { repository = "google/tarpc" }


### PR DESCRIPTION
In general, it should be possible to use, or at least import all functionality of a library, when having only that library in your cargo.toml

This means that commits which add things to the Cargo.toml, without also adding corresponding usage of those newly added libraries are usually a red flag.

This fixes such a problem introduced in #345, where usage of the serde_json feature tokio_serde::formats::Json required an additional import of tokio-serde with the json feature flag, rather than setting an appropriate tarpc feature flag.

This still doesn't enable the json featureflag by default, so the creator of #345 should still be happy