### PR TITLE
Fix example-service compilation

### DIFF
--- a/example-service/Cargo.toml
+++ b/example-service/Cargo.toml
@@ -15,7 +15,7 @@ description = "An example server built on tarpc."
 
 [dependencies]
 anyhow = "1.0"
-clap = "3.0.0-beta.2"
+clap = "3.0.0-beta.5"
 log = "0.4"
 futures = "0.3"
 opentelemetry = { version = "0.16", features = ["rt-tokio"] }

--- a/example-service/src/client.rs
+++ b/example-service/src/client.rs
@@ -4,14 +4,14 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-use clap::Clap;
+use clap::Parser;
 use service::{init_tracing, WorldClient};
 use std::{net::SocketAddr, time::Duration};
 use tarpc::{client, context, tokio_serde::formats::Json};
 use tokio::time::sleep;
 use tracing::Instrument;
 
-#[derive(Clap)]
+#[derive(Parser)]
 struct Flags {
     /// Sets the server address to connect to.
     #[clap(long)]

--- a/example-service/src/server.rs
+++ b/example-service/src/server.rs
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-use clap::Clap;
+use clap::Parser;
 use futures::{future, prelude::*};
 use rand::{
     distributions::{Distribution, Uniform},
@@ -22,7 +22,7 @@ use tarpc::{
 };
 use tokio::time;
 
-#[derive(Clap)]
+#[derive(Parser)]
 struct Flags {
     /// Sets the port number to listen on.
     #[clap(long)]


### PR DESCRIPTION
This PR fixes the compilation of the `example-service` crate (the `Clap` trait has been renamed `Parser` in https://github.com/clap-rs/clap/commit/d840d5650e9a7085a39c620697b11d6010d4fcf7).