### PR TITLE
adds PartialEq, Eq and Hash traits to RpcError

### DIFF
--- a/tarpc/src/client.rs
+++ b/tarpc/src/client.rs
@@ -168,7 +168,7 @@ struct ResponseGuard<'a, Resp> {
 
 /// An error that can occur in the processing of an RPC. This is not request-specific errors but
 /// rather cross-cutting errors that can always occur.
-#[derive(thiserror::Error, Debug, PartialEq, Eq, Hash)]
+#[derive(thiserror::Error, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum RpcError {
     /// The client disconnected from the server.
     #[error("the client disconnected from the server")]

--- a/tarpc/src/client.rs
+++ b/tarpc/src/client.rs
@@ -169,6 +169,7 @@ struct ResponseGuard<'a, Resp> {
 /// An error that can occur in the processing of an RPC. This is not request-specific errors but
 /// rather cross-cutting errors that can always occur.
 #[derive(thiserror::Error, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub enum RpcError {
     /// The client disconnected from the server.
     #[error("the client disconnected from the server")]

--- a/tarpc/src/client.rs
+++ b/tarpc/src/client.rs
@@ -168,7 +168,7 @@ struct ResponseGuard<'a, Resp> {
 
 /// An error that can occur in the processing of an RPC. This is not request-specific errors but
 /// rather cross-cutting errors that can always occur.
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, PartialEq, Eq, Hash)]
 pub enum RpcError {
     /// The client disconnected from the server.
     #[error("the client disconnected from the server")]


### PR DESCRIPTION
Tiny commit to derive these traits for `RpcError`. The underlying `ServerError` type already derives these traits therefore it should not be a problem to do so for RpcError.