### PR TITLE
Update opentelemetry and related dependencies

### DIFF
--- a/tarpc/Cargo.toml
+++ b/tarpc/Cargo.toml
@@ -2,7 +2,10 @@
 name = "tarpc"
 version = "0.27.2"
 rust-version = "1.56"
-authors = ["Adam Wright <adam.austin.wright@gmail.com>", "Tim Kuehn <timothy.j.kuehn@gmail.com>"]
+authors = [
+    "Adam Wright <adam.austin.wright@gmail.com>",
+    "Tim Kuehn <timothy.j.kuehn@gmail.com>",
+]
 edition = "2021"
 license = "MIT"
 documentation = "https://docs.rs/tarpc"
@@ -23,7 +26,14 @@ serde-transport-json = ["tokio-serde/json"]
 serde-transport-bincode = ["tokio-serde/bincode"]
 tcp = ["tokio/net"]
 
-full = ["serde1", "tokio1", "serde-transport", "serde-transport-json", "serde-transport-bincode", "tcp"]
+full = [
+    "serde1",
+    "tokio1",
+    "serde-transport",
+    "serde-transport-json",
+    "serde-transport-bincode",
+    "tcp",
+]
 
 [badges]
 travis-ci = { repository = "google/tarpc" }
@@ -40,11 +50,14 @@ static_assertions = "1.1.0"
 tarpc-plugins = { path = "../plugins", version = "0.12" }
 thiserror = "1.0"
 tokio = { version = "1", features = ["time"] }
-tokio-util = { version = "0.6.3", features = ["time"] }
+tokio-util = { version = "0.6.9", features = ["time"] }
 tokio-serde = { optional = true, version = "0.8" }
-tracing = { version = "0.1", default-features = false, features = ["attributes", "log"] }
-tracing-opentelemetry = { version = "0.15", default-features = false }
-opentelemetry = { version = "0.16", default-features = false }
+tracing = { version = "0.1", default-features = false, features = [
+    "attributes",
+    "log",
+] }
+tracing-opentelemetry = { version = "0.17.2", default-features = false }
+opentelemetry = { version = "0.17.0", default-features = false }
 
 
 [dev-dependencies]
@@ -53,11 +66,13 @@ bincode = "1.3"
 bytes = { version = "1", features = ["serde"] }
 flate2 = "1.0"
 futures-test = "0.3"
-opentelemetry = { version = "0.16", default-features = false, features = ["rt-tokio"] }
-opentelemetry-jaeger = { version = "0.15", features = ["rt-tokio"] }
+opentelemetry = { version = "0.17.0", default-features = false, features = [
+    "rt-tokio",
+] }
+opentelemetry-jaeger = { version = "0.16.0", features = ["rt-tokio"] }
 pin-utils = "0.1.0-alpha"
 serde_bytes = "0.11"
-tracing-subscriber = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1", features = ["full", "test-util"] }
 tokio-serde = { version = "0.8", features = ["json", "bincode"] }
 trybuild = "1.0"

--- a/tarpc/examples/pubsub.rs
+++ b/tarpc/examples/pubsub.rs
@@ -290,7 +290,7 @@ fn init_tracing(service_name: &str) -> anyhow::Result<()> {
         .install_batch(opentelemetry::runtime::Tokio)?;
 
     tracing_subscriber::registry()
-        .with(tracing_subscriber::EnvFilter::from_default_env())
+        .with(tracing_subscriber::filter::EnvFilter::from_default_env())
         .with(tracing_subscriber::fmt::layer())
         .with(tracing_opentelemetry::layer().with_tracer(tracer))
         .try_init()?;

--- a/tarpc/src/trace.rs
+++ b/tarpc/src/trace.rs
@@ -138,25 +138,25 @@ impl From<u64> for SpanId {
 
 impl From<opentelemetry::trace::TraceId> for TraceId {
     fn from(trace_id: opentelemetry::trace::TraceId) -> Self {
-        Self::from(trace_id.to_u128())
+        Self::from(u128::from_be_bytes(trace_id.to_bytes()))
     }
 }
 
 impl From<TraceId> for opentelemetry::trace::TraceId {
     fn from(trace_id: TraceId) -> Self {
-        Self::from_u128(trace_id.into())
+        Self::from_bytes(u128::from(trace_id).to_be_bytes())
     }
 }
 
 impl From<opentelemetry::trace::SpanId> for SpanId {
     fn from(span_id: opentelemetry::trace::SpanId) -> Self {
-        Self::from(span_id.to_u64())
+        Self::from(u64::from_be_bytes(span_id.to_bytes()))
     }
 }
 
 impl From<SpanId> for opentelemetry::trace::SpanId {
     fn from(span_id: SpanId) -> Self {
-        Self::from_u64(span_id.0)
+        Self::from_bytes(u64::from(span_id).to_be_bytes())
     }
 }
 


### PR DESCRIPTION
This is handy if you're working with other libraries/frameworks that depend on `opentelemetry 0.17`, as `tarpc` won't play well with them.
