### PR TITLE
Serialize RPC deadline as a Duration.

### DIFF
--- a/tarpc/examples/tracing.rs
+++ b/tarpc/examples/tracing.rs
@@ -6,7 +6,6 @@
 
 use crate::{add::Add as AddService, double::Double as DoubleService};
 use futures::{future, prelude::*};
-use std::env;
 use tarpc::{
     client, context,
     server::{incoming::Incoming, BaseChannel},
@@ -56,9 +55,9 @@ impl DoubleService for DoubleServer {
 }
 
 fn init_tracing(service_name: &str) -> anyhow::Result<()> {
-    env::set_var("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "12");
     let tracer = opentelemetry_jaeger::new_pipeline()
         .with_service_name(service_name)
+        .with_auto_split_batch(true)
         .with_max_packet_size(2usize.pow(13))
         .install_batch(opentelemetry::runtime::Tokio)?;
 

--- a/tarpc/src/client.rs
+++ b/tarpc/src/client.rs
@@ -114,6 +114,7 @@ impl<Req, Resp> Channel<Req, Resp> {
         skip(self, ctx, request_name, request),
         fields(
             rpc.trace_id = tracing::field::Empty,
+            rpc.deadline = %humantime::format_rfc3339(ctx.deadline),
             otel.kind = "client",
             otel.name = request_name)
         )]
@@ -519,11 +520,7 @@ where
             },
         });
         self.start_send(request)?;
-        let deadline = ctx.deadline;
-        tracing::info!(
-            tarpc.deadline = %humantime::format_rfc3339(deadline),
-            "SendRequest"
-        );
+        tracing::info!("SendRequest");
         drop(entered);
 
         self.in_flight_requests()

--- a/tarpc/src/server.rs
+++ b/tarpc/src/server.rs
@@ -161,6 +161,7 @@ where
         let span = info_span!(
             "RPC",
             rpc.trace_id = %request.context.trace_id(),
+            rpc.deadline = %humantime::format_rfc3339(request.context.deadline),
             otel.kind = "server",
             otel.name = tracing::field::Empty,
         );


### PR DESCRIPTION
Duration was previously serialized as `SystemTime`. However, absolute times run into problems with clock skew: if the remote machine's clock is too far in the future, the RPC deadline will be exceeded before request processing can begin. Conversely, if the remote machine's clock is too far in the past, the RPC deadline will not be enforced.

By converting the absolute deadline to a relative duration, clock skew is no longer relevant, as the remote machine will convert the deadline into a time relative to its own clock. This mirrors how the gRPC HTTP2 protocol includes a `Timeout` in the [request headers](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md) but the SDK uses [timestamps](https://grpc.io/blog/deadlines/#setting-a-deadline). Keeping the absolute time in the core APIs maintains all the benefits of today, namely, natural deadline propagation between RPC hops when using the current context.

This serialization strategy means that, generally, the remote machine's deadline will be slightly in the future compared to the local machine's deadline. Depending on network transfer latencies, this could be microseconds to milliseconds, or worse. Because the deadline is not intended for high-precision scenarios, I don't view this is as problematic.

Because this change only affects the serialization layer, local transports that bypass serialization are not affected.

Jaeger screenshot showing change in deadline between client and server:

![image](https://user-images.githubusercontent.com/2915777/170584191-b6fc6de5-cd2d-47d9-adb8-0e5c57d6a8de.png)

Fixes #366