### PR TITLE
feat: re-export used packages

### DIFF
--- a/example-service/Cargo.toml
+++ b/example-service/Cargo.toml
@@ -18,14 +18,14 @@ anyhow = "1.0"
 clap = { version = "3.0.0-rc.9", features = ["derive"] }
 log = "0.4"
 futures = "0.3"
-opentelemetry = { version = "0.16", features = ["rt-tokio"] }
-opentelemetry-jaeger = { version = "0.15", features = ["rt-tokio"] }
+opentelemetry = { version = "0.17", features = ["rt-tokio"] }
+opentelemetry-jaeger = { version = "0.16", features = ["rt-tokio"] }
 rand = "0.8"
 tarpc = { version = "0.29", path = "../tarpc", features = ["full"] }
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
 tracing = { version = "0.1" }
-tracing-opentelemetry = "0.15"
-tracing-subscriber = "0.2"
+tracing-opentelemetry = "0.17"
+tracing-subscriber = "0.3"
 
 [lib]
 name = "service"

--- a/example-service/Cargo.toml
+++ b/example-service/Cargo.toml
@@ -25,7 +25,7 @@ tarpc = { version = "0.29", path = "../tarpc", features = ["full"] }
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
 tracing = { version = "0.1" }
 tracing-opentelemetry = "0.17"
-tracing-subscriber = "0.3"
+tracing-subscriber = {version = "0.3", features = ["env-filter"]}
 
 [lib]
 name = "service"

--- a/tarpc/Cargo.toml
+++ b/tarpc/Cargo.toml
@@ -50,7 +50,7 @@ static_assertions = "1.1.0"
 tarpc-plugins = { path = "../plugins", version = "0.12" }
 thiserror = "1.0"
 tokio = { version = "1", features = ["time"] }
-tokio-util = { version = "0.6.9", features = ["time"] }
+tokio-util = { version = "0.7.3", features = ["time"] }
 tokio-serde = { optional = true, version = "0.8" }
 tracing = { version = "0.1", default-features = false, features = [
     "attributes",

--- a/tarpc/examples/custom_transport.rs
+++ b/tarpc/examples/custom_transport.rs
@@ -1,8 +1,9 @@
+use tarpc::context::Context;
 use tarpc::serde_transport as transport;
 use tarpc::server::{BaseChannel, Channel};
-use tarpc::{context::Context, tokio_serde::formats::Bincode};
+use tarpc::tokio_serde::formats::Bincode;
+use tarpc::tokio_util::codec::length_delimited::LengthDelimitedCodec;
 use tokio::net::{UnixListener, UnixStream};
-use tokio_util::codec::length_delimited::LengthDelimitedCodec;
 
 #[tarpc::service]
 pub trait PingService {

--- a/tarpc/examples/pubsub.rs
+++ b/tarpc/examples/pubsub.rs
@@ -52,9 +52,9 @@ use tarpc::{
     client, context,
     serde_transport::tcp,
     server::{self, Channel},
+    tokio_serde::formats::Json,
 };
 use tokio::net::ToSocketAddrs;
-use tokio_serde::formats::Json;
 use tracing::info;
 use tracing_subscriber::prelude::*;
 

--- a/tarpc/examples/tracing.rs
+++ b/tarpc/examples/tracing.rs
@@ -9,8 +9,8 @@ use futures::{future, prelude::*};
 use tarpc::{
     client, context,
     server::{incoming::Incoming, BaseChannel},
+    tokio_serde::formats::Json,
 };
-use tokio_serde::formats::Json;
 use tracing_subscriber::prelude::*;
 
 pub mod add {

--- a/tarpc/src/client.rs
+++ b/tarpc/src/client.rs
@@ -395,11 +395,7 @@ where
         // Receiving Poll::Ready(None) when polling expired requests never indicates "Closed",
         // because there can temporarily be zero in-flight rquests. Therefore, there is no need to
         // track the status like is done with pending and cancelled requests.
-        if let Poll::Ready(Some(_)) = self
-            .in_flight_requests()
-            .poll_expired(cx)
-            .map_err(ChannelError::Timer)?
-        {
+        if let Poll::Ready(Some(_)) = self.in_flight_requests().poll_expired(cx) {
             // Expired requests are considered complete; there is no compelling reason to send a
             // cancellation message to the server, since it will have already exhausted its
             // allotted processing time.

--- a/tarpc/src/lib.rs
+++ b/tarpc/src/lib.rs
@@ -209,7 +209,7 @@
 pub use serde;
 
 #[cfg(feature = "serde-transport")]
-pub use tokio_serde;
+pub use {tokio_serde, tokio_util};
 
 #[cfg(feature = "serde-transport")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde-transport")))]

--- a/tarpc/src/server.rs
+++ b/tarpc/src/server.rs
@@ -393,11 +393,7 @@ where
                 Poll::Pending | Poll::Ready(None) => Closed,
             };
 
-            let expiration_status = match self
-                .in_flight_requests_mut()
-                .poll_expired(cx)
-                .map_err(ChannelError::Timer)?
-            {
+            let expiration_status = match self.in_flight_requests_mut().poll_expired(cx) {
                 // No need to send a response, since the client wouldn't be waiting for one
                 // anymore.
                 Poll::Ready(Some(_)) => Ready,


### PR DESCRIPTION
### Problem

Library users might get stuck with or ran into issues while using tarpc because of incompatible third party libraries. in particular, `tokio_serde` and `tokio_util`.

### Solution

This PR hope to achive the following:

1. re-export struct from third party libraries that the end user would most likely import.
2. hide few types behind feature flags like tokio_serde::frmats::Json
3. Update third library packages to latest release and fix resulting issues from that.

### Important Notes

- tokio_util 7.3 [DelayQueue::poll_expired](https://docs.rs/tokio-util/latest/tokio_util/time/delay_queue/struct.DelayQueue.html#method.poll_expired) therefore, `InFlightRequests::poll_expired` now returns `Poll<Option<u64>>`

### Todo 

- [x] update documentation/example with re-export packages
- [ ] bump version

closes #370
