### PR TITLE
Fix Clippy Warnings

### DIFF
--- a/tarpc/src/client.rs
+++ b/tarpc/src/client.rs
@@ -628,7 +628,7 @@ mod tests {
     #[tokio::test]
     async fn response_completes_request_future() {
         let (mut dispatch, mut _channel, mut server_channel) = set_up();
-        let cx = &mut Context::from_waker(&noop_waker_ref());
+        let cx = &mut Context::from_waker(noop_waker_ref());
         let (tx, mut rx) = oneshot::channel();
 
         dispatch
@@ -656,7 +656,7 @@ mod tests {
             request_id: 3,
         });
         // resp's drop() is run, which should send a cancel message.
-        let cx = &mut Context::from_waker(&noop_waker_ref());
+        let cx = &mut Context::from_waker(noop_waker_ref());
         assert_eq!(canceled_requests.poll_recv(cx), Poll::Ready(Some(3)));
     }
 
@@ -679,14 +679,14 @@ mod tests {
         .await
         .unwrap();
         drop(cancellation);
-        let cx = &mut Context::from_waker(&noop_waker_ref());
+        let cx = &mut Context::from_waker(noop_waker_ref());
         assert_eq!(canceled_requests.poll_recv(cx), Poll::Ready(None));
     }
 
     #[tokio::test]
     async fn stage_request() {
         let (mut dispatch, mut channel, _server_channel) = set_up();
-        let cx = &mut Context::from_waker(&noop_waker_ref());
+        let cx = &mut Context::from_waker(noop_waker_ref());
         let (tx, mut rx) = oneshot::channel();
 
         let _resp = send_request(&mut channel, "hi", tx, &mut rx).await;
@@ -704,7 +704,7 @@ mod tests {
     #[tokio::test]
     async fn stage_request_channel_dropped_doesnt_panic() {
         let (mut dispatch, mut channel, mut server_channel) = set_up();
-        let cx = &mut Context::from_waker(&noop_waker_ref());
+        let cx = &mut Context::from_waker(noop_waker_ref());
         let (tx, mut rx) = oneshot::channel();
 
         let _ = send_request(&mut channel, "hi", tx, &mut rx).await;
@@ -726,7 +726,7 @@ mod tests {
     #[tokio::test]
     async fn stage_request_response_future_dropped_is_canceled_before_sending() {
         let (mut dispatch, mut channel, _server_channel) = set_up();
-        let cx = &mut Context::from_waker(&noop_waker_ref());
+        let cx = &mut Context::from_waker(noop_waker_ref());
         let (tx, mut rx) = oneshot::channel();
 
         let _ = send_request(&mut channel, "hi", tx, &mut rx).await;
@@ -742,7 +742,7 @@ mod tests {
     #[tokio::test]
     async fn stage_request_response_future_dropped_is_canceled_after_sending() {
         let (mut dispatch, mut channel, _server_channel) = set_up();
-        let cx = &mut Context::from_waker(&noop_waker_ref());
+        let cx = &mut Context::from_waker(noop_waker_ref());
         let (tx, mut rx) = oneshot::channel();
 
         let req = send_request(&mut channel, "hi", tx, &mut rx).await;
@@ -763,7 +763,7 @@ mod tests {
     #[tokio::test]
     async fn stage_request_response_closed_skipped() {
         let (mut dispatch, mut channel, _server_channel) = set_up();
-        let cx = &mut Context::from_waker(&noop_waker_ref());
+        let cx = &mut Context::from_waker(noop_waker_ref());
         let (tx, mut rx) = oneshot::channel();
 
         // Test that a request future that's closed its receiver but not yet canceled its request --
@@ -796,7 +796,7 @@ mod tests {
 
         let dispatch = RequestDispatch::<String, String, _> {
             transport: client_channel.fuse(),
-            pending_requests: pending_requests,
+            pending_requests,
             canceled_requests,
             in_flight_requests: InFlightRequests::default(),
             config: Config::default(),

--- a/tarpc/src/serde_transport.rs
+++ b/tarpc/src/serde_transport.rs
@@ -291,7 +291,7 @@ mod tests {
     use tokio_serde::formats::SymmetricalJson;
 
     fn ctx() -> Context<'static> {
-        Context::from_waker(&noop_waker_ref())
+        Context::from_waker(noop_waker_ref())
     }
 
     struct TestIo(Cursor<Vec<u8>>);

--- a/tarpc/src/server.rs
+++ b/tarpc/src/server.rs
@@ -837,9 +837,10 @@ mod tests {
         channel::Channel<Response<Resp>, ClientMessage<Req>>,
     ) {
         let (tx, rx) = crate::transport::channel::bounded(capacity);
-        let mut config = Config::default();
         // Add 1 because capacity 0 is not supported (but is supported by transport::channel::bounded).
-        config.pending_response_buffer = capacity + 1;
+        let config = Config {
+            pending_response_buffer: capacity + 1,
+        };
         (Box::pin(BaseChannel::new(config, rx).requests()), tx)
     }
 

--- a/tarpc/src/server/in_flight_requests.rs
+++ b/tarpc/src/server/in_flight_requests.rs
@@ -176,7 +176,7 @@ mod tests {
             .unwrap();
         let mut abortable_future = Box::new(Abortable::new(pending::<()>(), abort_registration));
 
-        assert_eq!(in_flight_requests.cancel_request(0), true);
+        assert!(in_flight_requests.cancel_request(0));
         assert_matches!(
             abortable_future.poll_unpin(&mut noop_context()),
             Poll::Ready(Err(_))

--- a/tarpc/src/server/limits/channels_per_key.rs
+++ b/tarpc/src/server/limits/channels_per_key.rs
@@ -282,7 +282,7 @@ where
 fn ctx() -> Context<'static> {
     use futures::task::*;
 
-    Context::from_waker(&noop_waker_ref())
+    Context::from_waker(noop_waker_ref())
 }
 
 #[test]

--- a/tarpc/src/server/testing.rs
+++ b/tarpc/src/server/testing.rs
@@ -134,5 +134,5 @@ impl<T> PollExt for Poll<Option<T>> {
 }
 
 pub fn cx() -> Context<'static> {
-    Context::from_waker(&noop_waker_ref())
+    Context::from_waker(noop_waker_ref())
 }

--- a/tarpc/tests/dataservice.rs
+++ b/tarpc/tests/dataservice.rs
@@ -7,7 +7,7 @@ use tarpc::{
 use tokio_serde::formats::Json;
 
 #[tarpc::derive_serde]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum TestData {
     Black,
     White,


### PR DESCRIPTION
# Fixed Following Cippy Warnings

- Needless-borrow
- redundant_field_names
- field_reassign_with_default
- bool_assert_comparison
- derive_partial_eq_without_eq

Fixes #378 
