### PR TITLE
feat: Unix domain sockets with serde transports

### DIFF
--- a/tarpc/Cargo.toml
+++ b/tarpc/Cargo.toml
@@ -25,6 +25,7 @@ serde-transport = ["serde1", "tokio1", "tokio-serde", "tokio-util/codec"]
 serde-transport-json = ["tokio-serde/json"]
 serde-transport-bincode = ["tokio-serde/bincode"]
 tcp = ["tokio/net"]
+unix = ["tokio/net"]
 
 full = [
     "serde1",
@@ -33,6 +34,7 @@ full = [
     "serde-transport-json",
     "serde-transport-bincode",
     "tcp",
+    "unix",
 ]
 
 [badges]

--- a/tarpc/src/serde_transport.rs
+++ b/tarpc/src/serde_transport.rs
@@ -433,22 +433,27 @@ pub mod unix {
     pub struct TempSock(std::path::PathBuf);
 
     impl TempSock {
-        /// A named socket that results in `<name>.sock`
+        /// A named socket that results in `<tempdir>/<name>.sock`
         pub fn new<S: AsRef<str>>(name: S) -> Self {
+            Self::exact(format!("{}.sock", name.as_ref()))
+        }
+
+        /// A named socket that uses the name exactly as passed without allocating a new `String`
+        /// to add `.sock`, this results in `<tempdir>/<name>`
+        pub fn exact<S: AsRef<str>>(name: S) -> Self {
             let mut sock = std::env::temp_dir();
-            sock.push(format!("{}.sock", name.as_ref()));
+            sock.push(name.as_ref());
             Self(sock)
         }
 
-        /// Appends a random hex string to the socket name resulting in `<name>_<xxxxx>.sock`
+        /// Appends a random hex string to the socket name resulting in
+        /// `<tempdir>/<name>_<xxxxx>.sock`
         pub fn with_random<S: AsRef<str>>(name: S) -> Self {
-            let mut sock = std::env::temp_dir();
-            sock.push(format!(
+            Self::exact(format!(
                 "{}_{:x}.sock",
                 name.as_ref(),
                 rand::random::<u64>()
-            ));
-            Self(sock)
+            ))
         }
     }
 

--- a/tarpc/src/serde_transport.rs
+++ b/tarpc/src/serde_transport.rs
@@ -289,14 +289,6 @@ pub mod unix {
         tokio_util::codec::length_delimited,
     };
 
-    mod private {
-        use super::*;
-
-        pub trait Sealed {}
-
-        impl<Item, SinkItem, Codec> Sealed for Transport<UnixStream, Item, SinkItem, Codec> {}
-    }
-
     impl<Item, SinkItem, Codec> Transport<UnixStream, Item, SinkItem, Codec> {
         /// Returns the socket address of the remote half of the underlying [`UnixStream`].
         pub fn peer_addr(&self) -> io::Result<SocketAddr> {

--- a/tarpc/src/serde_transport.rs
+++ b/tarpc/src/serde_transport.rs
@@ -430,7 +430,7 @@ pub mod unix {
 
         fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
             let conn: UnixStream =
-                ready!(Pin::new(&mut self.as_mut().project().listener).poll_accept(cx)?).0;
+                ready!(self.as_mut().project().listener.poll_accept(cx)?).0;
             Poll::Ready(Some(Ok(new(
                 self.config.new_framed(conn),
                 (self.codec_fn)(),

--- a/tarpc/src/serde_transport.rs
+++ b/tarpc/src/serde_transport.rs
@@ -468,6 +468,24 @@ pub mod unix {
             let _ = std::fs::remove_file(&self.0);
         }
     }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use tokio_serde::formats::SymmetricalJson;
+
+        #[tokio::test]
+        async fn temp_sock_removed_on_drop() {
+            let sock = TempSock::new("test");
+            // Save path for testing after drop
+            let sock_path = std::path::PathBuf::from(sock.as_ref());
+            // create the actual socket
+            let _ = listen(&sock, SymmetricalJson::<String>::default).await;
+            assert!(sock_path.exists());
+            std::mem::drop(sock);
+            assert!(!sock_path.exists());
+        }
+    }
 }
 
 #[cfg(test)]

--- a/tarpc/src/serde_transport.rs
+++ b/tarpc/src/serde_transport.rs
@@ -429,8 +429,7 @@ pub mod unix {
         type Item = io::Result<Transport<UnixStream, Item, SinkItem, Codec>>;
 
         fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-            let conn: UnixStream =
-                ready!(self.as_mut().project().listener.poll_accept(cx)?).0;
+            let conn: UnixStream = ready!(self.as_mut().project().listener.poll_accept(cx)?).0;
             Poll::Ready(Some(Ok(new(
                 self.config.new_framed(conn),
                 (self.codec_fn)(),

--- a/tarpc/tests/compile_fail/serde_transport/must_use_tcp_connect.stderr
+++ b/tarpc/tests/compile_fail/serde_transport/must_use_tcp_connect.stderr
@@ -1,4 +1,4 @@
-error: unused `Connect` that must be used
+error: unused `tarpc::serde_transport::tcp::Connect` that must be used
  --> tests/compile_fail/serde_transport/must_use_tcp_connect.rs:7:9
   |
 7 |         serde_transport::tcp::connect::<_, (), (), _, _>("0.0.0.0:0", Json::default);

--- a/tarpc/tests/service_functional.rs
+++ b/tarpc/tests/service_functional.rs
@@ -144,7 +144,7 @@ async fn serde_uds() -> anyhow::Result<()> {
 
     let _ = tracing_subscriber::fmt::try_init();
 
-    let sock = tarpc::serde_transport::unix::TempSock::with_random("uds");
+    let sock = tarpc::serde_transport::unix::TempPathBuf::with_random("uds");
     let transport = tarpc::serde_transport::unix::listen(&sock, Json::default).await?;
     tokio::spawn(
         transport


### PR DESCRIPTION
Picks up where #369 apparently stalled. Funny fact I didn't look at existing PRs when doing this, so we just happened to pick almost identical impls since it's basically just copying the `tcp` module.

All tests are passing locally, I've also run this through a local application I have using unix sockets and it appears to work as desired.

The unix sockets are behind the feature flag `unix` and in the `unix` module to keep modules similar to those in Tokio and std. They are also gated by the target OS being a unix flavor as well.

~There's one minor additional tag along commit of a UI test that was failing on master.~ (edit: looks like that may have been an artifact of me testing with nightly. It's been removed).