### PR TITLE
Update OpenTelemetry Packages in Example App

### DIFF
--- a/example-service/Cargo.toml
+++ b/example-service/Cargo.toml
@@ -18,14 +18,15 @@ anyhow = "1.0"
 clap = { version = "3.0.0-rc.9", features = ["derive"] }
 log = "0.4"
 futures = "0.3"
-opentelemetry = { version = "0.17", features = ["rt-tokio"] }
-opentelemetry-jaeger = { version = "0.16", features = ["rt-tokio"] }
+opentelemetry = { version = "0.21.0" }
+opentelemetry-jaeger = { version = "0.20.0", features = ["rt-tokio"] }
 rand = "0.8"
 tarpc = { version = "0.33", path = "../tarpc", features = ["full"] }
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
 tracing = { version = "0.1" }
-tracing-opentelemetry = "0.17"
-tracing-subscriber = {version = "0.3", features = ["env-filter"]}
+tracing-opentelemetry = "0.22.0"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+opentelemetry_sdk = "0.21.1"
 
 [lib]
 name = "service"

--- a/example-service/README.md
+++ b/example-service/README.md
@@ -1,0 +1,15 @@
+# Example
+
+Example service to demonstrate how to set up `tarpc` with [Jaeger](https://www.jaegertracing.io). To see traces Jaeger, run the following with `RUST_LOG=trace`.
+
+## Server
+
+```bash
+cargo run --bin server -- --port 50051
+```
+
+## Client
+
+```bash
+cargo run --bin client -- --server-addr "[::1]:50051" --name "Bob"
+```

--- a/example-service/src/lib.rs
+++ b/example-service/src/lib.rs
@@ -19,10 +19,10 @@ pub trait World {
 pub fn init_tracing(service_name: &str) -> anyhow::Result<()> {
     env::set_var("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "12");
 
-    let tracer = opentelemetry_jaeger::new_pipeline()
+    let tracer = opentelemetry_jaeger::new_agent_pipeline()
         .with_service_name(service_name)
         .with_max_packet_size(2usize.pow(13))
-        .install_batch(opentelemetry::runtime::Tokio)?;
+        .install_batch(opentelemetry_sdk::runtime::Tokio)?;
 
     tracing_subscriber::registry()
         .with(tracing_subscriber::EnvFilter::from_default_env())


### PR DESCRIPTION
This just updates the OpenTelemetry setup in the example app. For beginners like me, a mention in the docs that `RUST_LOG`  is required to be set to see the service in Jaeger would be nice (not sure if that belongs in this repo though).