### PR TITLE
Allow use of custom Result

### DIFF
--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -431,7 +431,7 @@ impl<'a> ServiceGenerator<'a> {
                 }
 
                 async fn serve(self, ctx: tarpc::context::Context, req: #request_ident)
-                    -> Result<#response_ident, tarpc::ServerError> {
+                    -> std::result::Result<#response_ident, tarpc::ServerError> {
                     match req {
                         #(
                             #request_ident::#camel_case_idents{ #( #arg_pats ),* } => {
@@ -578,7 +578,7 @@ impl<'a> ServiceGenerator<'a> {
                     #[allow(unused)]
                     #( #method_attrs )*
                     #vis fn #method_idents(&self, ctx: tarpc::context::Context, #( #args ),*)
-                        -> impl std::future::Future<Output = Result<#return_types, tarpc::client::RpcError>> + '_ {
+                        -> impl std::future::Future<Output = std::result::Result<#return_types, tarpc::client::RpcError>> + '_ {
                         let request = #request_ident::#camel_case_idents { #( #arg_pats ),* };
                         let resp = self.0.call(ctx, #request_names, request);
                         async move {


### PR DESCRIPTION
This PR allows to use custom `Result` type in `tarpc::service`

I.e, this code fails to compile with `0.34.0`:

```rust
#[derive(Debug)]
enum Error {
    Msg(String),
}

impl std::fmt::Display for Error {
    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
        match self {
            Self::Msg(msg) => f.write_str(msg),
        }
    }
}

impl std::error::Error for Error {}

type Result<T> = std::result::Result<T, Error>;

#[tarpc::service]
trait Test {
    async fn method() -> Result<()>;
}
```
Error message is
```
error[E0107]: type alias takes 1 generic argument but 2 generic arguments were supplied
  --> src/main.rs:19:1
   |
19 | #[tarpc::service]
   | ^^^^^^^^^^^^^^^^^
   | |
   | expected 1 generic argument
   | help: remove this generic argument
   |
note: type alias defined here, with 1 generic parameter: `T`
  --> src/main.rs:17:6
   |
17 | type Result<T> = std::result::Result<T, Error>;
   |      ^^^^^^ -
   = note: this error originates in the attribute macro `tarpc::service` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0271]: expected `impl Future<Output = Result<TestResponse, Error>>` to be a future that resolves to `Result<TestResponse, ServerError>`, but it resolves to `Result<TestResponse, Error>`
  --> src/main.rs:19:1
   |
19 | #[tarpc::service]
   | ^^^^^^^^^^^^^^^^^ expected `Result<TestResponse, ServerError>`, found `Result<TestResponse, Error>`
   |
   = note: expected enum `std::result::Result<_, ServerError>`
              found enum `std::result::Result<_, Error>`
note: required by a bound in `Serve::{opaque#0}`
  --> /home/remi/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tarpc-0.34.0/src/server.rs:79:5
   |
79 |     async fn serve(self, ctx: context::Context, req: Self::Req) -> Result<Self::Resp, ServerError>;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Serve::{opaque#0}`
```