### PR TITLE
 Add support for #[cfg(…)] attributes on rpc trait definition

### DIFF
--- a/plugins/tests/service.rs
+++ b/plugins/tests/service.rs
@@ -57,6 +57,20 @@ fn raw_idents() {
 }
 
 #[test]
+fn service_with_cfg_rpc() {
+    #[tarpc::service]
+    trait Foo {
+        async fn foo();
+        #[cfg(not(test))]
+        async fn bar(s: String) -> String;
+    }
+
+    impl Foo for () {
+        async fn foo(self, _: context::Context) {}
+    }
+}
+
+#[test]
 fn syntax() {
     #[tarpc::service]
     trait Syntax {


### PR DESCRIPTION
Currently it's not possible to use a `#[cfg(…)]` attribute on a method.
```rust
#[tarpc::service]
pub trait World {
    #[cfg(feature = "hello")]
    async fn hello() -> String;
}
```
Would result in:
```
error[E0599]: no function or associated item named `hello` found for trait `World`
 --> rpc/src/lib.rs:8:14
  |
5 |   pub trait World {
  |  ___________-
6 | |     /// Returns a greeting for name.
7 | |     #[cfg(feature = "hello")]
8 | |     async fn hello() -> String;
  | |             -^^^^^ function or associated item not found in `World`
  | |_____________|
  |

For more information about this error, try `rustc --explain E0599`.
error: could not compile `rpc` (lib) due to previous error
```

This PR propose to simply propagate *all* attributes to every enum, and impl that are linked to a given rpc.
Obviously this might cause issue with attributes that are only supposed to be used on function.

Would this kind of solution be acceptable? If not, what kind of solution would you consider to enable `#[cfg(…)]` usage?