### PR TITLE
Fix CI workflow file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,19 +11,11 @@ on:
 
 name: Continuous Integration
 
-jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel previous
-        uses: styfle/cancel-workflow-action@0.10.0
-        with:
-          access_token: ${{ github.token }}
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo check --all-features
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number ||  github.ref }}"
+  cancel-in-progress: "${{ github.ref != 'refs/heads/master' }}"
 
+jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -50,10 +42,6 @@ jobs:
           - unix: "--features unix"
             serde-transport: ""
     steps:
-      - name: Cancel previous
-        uses: styfle/cancel-workflow-action@0.10.0
-        with:
-          access_token: ${{ github.token }}
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: >
@@ -68,10 +56,6 @@ jobs:
     outputs:
       examples: ${{ steps.matrix.outputs.examples }}
     steps:
-      - name: Cancel previous
-        uses: styfle/cancel-workflow-action@0.10.0
-        with:
-          access_token: ${{ github.token }}
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - id: matrix
@@ -95,10 +79,6 @@ jobs:
       matrix:
         example: ${{ fromJSON(needs.list-examples.outputs.examples) }}
     steps:
-      - name: Cancel previous
-        uses: styfle/cancel-workflow-action@0.10.0
-        with:
-          access_token: ${{ github.token }}
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: |
@@ -108,10 +88,6 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel previous
-        uses: styfle/cancel-workflow-action@0.10.0
-        with:
-          access_token: ${{ github.token }}
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -122,10 +98,6 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel previous
-        uses: styfle/cancel-workflow-action@0.10.0
-        with:
-          access_token: ${{ github.token }}
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -137,7 +109,7 @@ jobs:
   test-suite:
     name: Test Suite
     runs-on: ubuntu-latest
-    needs: [test, run-example]
+    needs: [test, run-example, fmt, clippy]
     if: always()
     steps:
       - name: All tests ok

--- a/example-service/Cargo.toml
+++ b/example-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tarpc-example-service"
 version = "0.15.0"
-rust-version = "1.56"
+rust-version = "1.65.0"
 authors = ["Tim Kuehn <tikue@google.com>"]
 edition = "2021"
 license = "MIT"

--- a/plugins/Cargo.toml
+++ b/plugins/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tarpc-plugins"
 version = "0.13.1"
-rust-version = "1.56"
+rust-version = "1.65.0"
 authors = ["Adam Wright <adam.austin.wright@gmail.com>", "Tim Kuehn <timothy.j.kuehn@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/tarpc/Cargo.toml
+++ b/tarpc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tarpc"
 version = "0.34.0"
-rust-version = "1.58.0"
+rust-version = "1.65.0"
 authors = [
     "Adam Wright <adam.austin.wright@gmail.com>",
     "Tim Kuehn <timothy.j.kuehn@gmail.com>",

--- a/tarpc/src/client.rs
+++ b/tarpc/src/client.rs
@@ -136,7 +136,7 @@ where
             );
             ctx.trace_context.new_child()
         });
-        span.record("rpc.trace_id", &tracing::field::display(ctx.trace_id()));
+        span.record("rpc.trace_id", tracing::field::display(ctx.trace_id()));
         let (response_completion, mut response) = oneshot::channel();
         let request_id =
             u64::try_from(self.next_request_id.fetch_add(1, Ordering::Relaxed)).unwrap();


### PR DESCRIPTION
The final step didn't include the Clippy and format tests. So even if those failed, PRs could get merged anyway. This now depends on all steps.

Also, the cancel-workflow-action is no longer necessary, as stated in the README of the workflow. GHA has implemented this feature by now.

Also removes the `check` step, as the final test didn't depend on it, it didn't use `-Dwarnings`, and this is also covered by the `clippy` step.

This should now fail CI in the PR, as the clippy check currently fails.