### PR TITLE
Update all tracing dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - run: cargo clippy --all-features -- -D warnings
+      - run: cargo clippy --all-features --all-targets -- -D warnings
 
   # This job succeeds if all other tests and examples succeed. Otherwise, it fails. It is for use in
   # branch protection rules.

--- a/example-service/Cargo.toml
+++ b/example-service/Cargo.toml
@@ -18,15 +18,16 @@ anyhow = "1.0"
 clap = { version = "4.4.18", features = ["derive"] }
 log = "0.4"
 futures = "0.3"
-opentelemetry = { version = "0.21.0" }
-opentelemetry-jaeger = { version = "0.20.0", features = ["rt-tokio"] }
+opentelemetry = { version = "0.24.0" }
+opentelemetry-otlp = "0.17.0"
 rand = "0.8"
 tarpc = { version = "0.34", path = "../tarpc", features = ["full"] }
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
 tracing = { version = "0.1" }
-tracing-opentelemetry = "0.22.0"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-opentelemetry_sdk = "0.21.2"
+tracing-opentelemetry = "0.25.0"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+opentelemetry_sdk = { version = "0.24.1", features = ["rt-tokio"] }
+opentelemetry-semantic-conventions = "0.16.0"
 
 [lib]
 name = "service"

--- a/example-service/README.md
+++ b/example-service/README.md
@@ -1,6 +1,6 @@
 # Example
 
-Example service to demonstrate how to set up `tarpc` with [Jaeger](https://www.jaegertracing.io). To see traces Jaeger, run the following with `RUST_LOG=trace`.
+Example service to demonstrate how to set up `tarpc` with [Jaeger](https://www.jaegertracing.io) using OTLP. To see traces Jaeger, run the following with `RUST_LOG=trace`.
 
 ## Server
 

--- a/example-service/src/lib.rs
+++ b/example-service/src/lib.rs
@@ -4,7 +4,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-use std::env;
+use opentelemetry::trace::TracerProvider as _;
 use tracing_subscriber::{fmt::format::FmtSpan, prelude::*};
 
 /// This is the service definition. It looks a lot like a trait definition.
@@ -15,14 +15,21 @@ pub trait World {
     async fn hello(name: String) -> String;
 }
 
-/// Initializes an OpenTelemetry tracing subscriber with a Jaeger backend.
-pub fn init_tracing(service_name: &str) -> anyhow::Result<()> {
-    env::set_var("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "12");
-
-    let tracer = opentelemetry_jaeger::new_agent_pipeline()
-        .with_service_name(service_name)
-        .with_max_packet_size(2usize.pow(13))
+/// Initializes an OpenTelemetry tracing subscriber with a OTLP backend.
+pub fn init_tracing(service_name: &'static str) -> anyhow::Result<()> {
+    let tracer_provider = opentelemetry_otlp::new_pipeline()
+        .tracing()
+        .with_trace_config(opentelemetry_sdk::trace::Config::default().with_resource(
+            opentelemetry_sdk::Resource::new([opentelemetry::KeyValue::new(
+                opentelemetry_semantic_conventions::resource::SERVICE_NAME,
+                service_name,
+            )]),
+        ))
+        .with_batch_config(opentelemetry_sdk::trace::BatchConfig::default())
+        .with_exporter(opentelemetry_otlp::new_exporter().tonic())
         .install_batch(opentelemetry_sdk::runtime::Tokio)?;
+    opentelemetry::global::set_tracer_provider(tracer_provider.clone());
+    let tracer = tracer_provider.tracer(service_name);
 
     tracing_subscriber::registry()
         .with(tracing_subscriber::EnvFilter::from_default_env())

--- a/plugins/tests/service.rs
+++ b/plugins/tests/service.rs
@@ -20,9 +20,7 @@ fn att_service_trait() {
             s
         }
 
-        async fn baz(self, _: context::Context) {
-            ()
-        }
+        async fn baz(self, _: context::Context) {}
     }
 }
 
@@ -52,9 +50,7 @@ fn raw_idents() {
             r#impl
         }
 
-        async fn r#async(self, _: context::Context) {
-            ()
-        }
+        async fn r#async(self, _: context::Context) {}
     }
 }
 

--- a/tarpc/Cargo.toml
+++ b/tarpc/Cargo.toml
@@ -58,9 +58,9 @@ tracing = { version = "0.1", default-features = false, features = [
     "attributes",
     "log",
 ] }
-tracing-opentelemetry = { version = "0.22.0", default-features = false }
-opentelemetry = { version = "0.21.0", default-features = false }
-
+tracing-opentelemetry = { version = "0.25.0", default-features = false }
+opentelemetry = { version = "0.24.0", default-features = false }
+opentelemetry-semantic-conventions = "0.16.0"
 
 [dev-dependencies]
 assert_matches = "1.4"
@@ -68,10 +68,10 @@ bincode = "1.3"
 bytes = { version = "1", features = ["serde"] }
 flate2 = "1.0"
 futures-test = "0.3"
-opentelemetry = { version = "0.21.0", default-features = false }
-opentelemetry-jaeger = { version = "0.20.0", features = ["rt-tokio"] }
-opentelemetry_sdk = "0.21.2"
-pin-utils = "0.1.0-alpha"
+opentelemetry = { version = "0.24.0", default-features = false }
+opentelemetry-otlp = "0.17.0"
+opentelemetry_sdk = { version = "0.24.1", features = ["rt-tokio"] }
+pin-utils = "0.1.0"
 serde_bytes = "0.11"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1", features = ["full", "test-util", "tracing"] }

--- a/tarpc/examples/pubsub.rs
+++ b/tarpc/examples/pubsub.rs
@@ -223,7 +223,7 @@ impl Publisher {
             for topic in topics {
                 subscriptions
                     .entry(topic)
-                    .or_insert_with(HashMap::new)
+                    .or_default()
                     .insert(subscriber_addr, subscriber.clone());
             }
         }

--- a/tarpc/examples/pubsub.rs
+++ b/tarpc/examples/pubsub.rs
@@ -38,10 +38,10 @@ use futures::{
     future::{self, AbortHandle},
     prelude::*,
 };
+use opentelemetry::trace::TracerProvider as _;
 use publisher::Publisher as _;
 use std::{
     collections::HashMap,
-    env,
     error::Error,
     io,
     net::SocketAddr,
@@ -283,16 +283,24 @@ impl publisher::Publisher for Publisher {
     }
 }
 
-/// Initializes an OpenTelemetry tracing subscriber with a Jaeger backend.
-fn init_tracing(service_name: &str) -> anyhow::Result<()> {
-    env::set_var("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "12");
-    let tracer = opentelemetry_jaeger::new_agent_pipeline()
-        .with_service_name(service_name)
-        .with_max_packet_size(2usize.pow(13))
+/// Initializes an OpenTelemetry tracing subscriber with a OTLP backend.
+pub fn init_tracing(service_name: &'static str) -> anyhow::Result<()> {
+    let tracer_provider = opentelemetry_otlp::new_pipeline()
+        .tracing()
+        .with_batch_config(opentelemetry_sdk::trace::BatchConfig::default())
+        .with_exporter(opentelemetry_otlp::new_exporter().tonic())
+        .with_trace_config(opentelemetry_sdk::trace::Config::default().with_resource(
+            opentelemetry_sdk::Resource::new([opentelemetry::KeyValue::new(
+                opentelemetry_semantic_conventions::resource::SERVICE_NAME,
+                service_name,
+            )]),
+        ))
         .install_batch(opentelemetry_sdk::runtime::Tokio)?;
+    opentelemetry::global::set_tracer_provider(tracer_provider.clone());
+    let tracer = tracer_provider.tracer(service_name);
 
     tracing_subscriber::registry()
-        .with(tracing_subscriber::filter::EnvFilter::from_default_env())
+        .with(tracing_subscriber::EnvFilter::from_default_env())
         .with(tracing_subscriber::fmt::layer())
         .with(tracing_opentelemetry::layer().with_tracer(tracer))
         .try_init()?;

--- a/tarpc/examples/tls_over_tcp.rs
+++ b/tarpc/examples/tls_over_tcp.rs
@@ -102,7 +102,7 @@ async fn main() -> anyhow::Result<()> {
 
     let config = rustls::ServerConfig::builder()
         .with_client_cert_verifier(client_auth) // use .with_no_client_auth() instead if you don't want client-auth
-        .with_single_cert(cert, key.into())
+        .with_single_cert(cert, key)
         .unwrap();
     let acceptor = TlsAcceptor::from(Arc::new(config));
     let listener = TcpListener::bind(&server_addr).await.unwrap();

--- a/tarpc/examples/tracing.rs
+++ b/tarpc/examples/tracing.rs
@@ -134,15 +134,14 @@ where
             .map(|transport| tarpc::client::new(client::Config::default(), transport).spawn())
             .collect(),
     );
-    let stub = retry::Retry::new(stub, |resp, attempts| {
+    retry::Retry::new(stub, |resp, attempts| {
         if let Err(e) = resp {
             tracing::warn!("Got an error: {e:?}");
             attempts < 3
         } else {
             false
         }
-    });
-    stub
+    })
 }
 
 #[tokio::main]

--- a/tarpc/examples/tracing.rs
+++ b/tarpc/examples/tracing.rs
@@ -9,6 +9,7 @@ use crate::{
     double::Double as DoubleService,
 };
 use futures::{future, prelude::*};
+use opentelemetry::trace::TracerProvider as _;
 use std::{
     io,
     sync::{
@@ -76,12 +77,21 @@ where
     }
 }
 
-fn init_tracing(service_name: &str) -> anyhow::Result<()> {
-    let tracer = opentelemetry_jaeger::new_agent_pipeline()
-        .with_service_name(service_name)
-        .with_auto_split_batch(true)
-        .with_max_packet_size(2usize.pow(13))
+/// Initializes an OpenTelemetry tracing subscriber with a OTLP backend.
+pub fn init_tracing(service_name: &'static str) -> anyhow::Result<()> {
+    let tracer_provider = opentelemetry_otlp::new_pipeline()
+        .tracing()
+        .with_batch_config(opentelemetry_sdk::trace::BatchConfig::default())
+        .with_exporter(opentelemetry_otlp::new_exporter().tonic())
+        .with_trace_config(opentelemetry_sdk::trace::Config::default().with_resource(
+            opentelemetry_sdk::Resource::new([opentelemetry::KeyValue::new(
+                opentelemetry_semantic_conventions::resource::SERVICE_NAME,
+                service_name,
+            )]),
+        ))
         .install_batch(opentelemetry_sdk::runtime::Tokio)?;
+    opentelemetry::global::set_tracer_provider(tracer_provider.clone());
+    let tracer = tracer_provider.tracer(service_name);
 
     tracing_subscriber::registry()
         .with(tracing_subscriber::EnvFilter::from_default_env())

--- a/tarpc/src/lib.rs
+++ b/tarpc/src/lib.rs
@@ -41,7 +41,7 @@
 //! - Distributed tracing: tarpc is instrumented with
 //!   [tracing](https://github.com/tokio-rs/tracing) primitives extended with
 //!   [OpenTelemetry](https://opentelemetry.io/) traces. Using a compatible tracing subscriber like
-//!   [Jaeger](https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-jaeger),
+//!   [OTLP](https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-otlp),
 //!   each RPC can be traced through the client, server, and other dependencies downstream of the
 //!   server. Even for applications not connected to a distributed tracing collector, the
 //!   instrumentation can also be ingested by regular loggers like

--- a/tarpc/src/server/limits/requests_per_channel.rs
+++ b/tarpc/src/server/limits/requests_per_channel.rs
@@ -249,7 +249,7 @@ mod tests {
         throttler.inner.push_req(1, 1);
         assert!(throttler.as_mut().poll_next(&mut testing::cx()).is_done());
         assert_eq!(throttler.inner.sink.len(), 1);
-        let resp = throttler.inner.sink.get(0).unwrap();
+        let resp = throttler.inner.sink.front().unwrap();
         assert_eq!(resp.request_id, 1);
         assert!(resp.message.is_err());
     }
@@ -331,7 +331,7 @@ mod tests {
             .unwrap();
         assert_eq!(throttler.inner.in_flight_requests.len(), 0);
         assert_eq!(
-            throttler.inner.sink.get(0),
+            throttler.inner.sink.front(),
             Some(&Response {
                 request_id: 0,
                 message: Ok(1),


### PR DESCRIPTION
Those dependencies were really out of date. The opentelemetry-jaeger dependencies was even deprecated. This bumps all those dependencies to the latest version and replaces jaeger with otlp, like recommended by the opentelemetry project.

---

While doing this, I noticed that Clippy didn't run on tests and examples. I changed that in 2f7ef0015d96fd52ccd15e5ce99b2d11a5637af6 and fixed the fallout. Let me know if I should drop this commit or if you want me to open a separate PR for it.