### PR TITLE
Reformat with rustfmt 1.8.0-nightly to unbreak rustfmt CI job

### DIFF
--- a/tarpc/src/server/request_hook/before.rs
+++ b/tarpc/src/server/request_hook/before.rs
@@ -157,7 +157,10 @@ impl<Req> BeforeRequest<Req> for BeforeRequestNil {
 impl<Req, First: BeforeRequest<Req>, Rest: BeforeRequestList<Req>> BeforeRequestList<Req>
     for BeforeRequestCons<First, Rest>
 {
-    type Then<Next> = BeforeRequestCons<First, Rest::Then<Next>> where Next: BeforeRequest<Req>;
+    type Then<Next>
+        = BeforeRequestCons<First, Rest::Then<Next>>
+    where
+        Next: BeforeRequest<Req>;
 
     fn then<Next: BeforeRequest<Req>>(self, next: Next) -> Self::Then<Next> {
         let BeforeRequestCons(first, rest) = self;
@@ -172,7 +175,10 @@ impl<Req, First: BeforeRequest<Req>, Rest: BeforeRequestList<Req>> BeforeRequest
 }
 
 impl<Req> BeforeRequestList<Req> for BeforeRequestNil {
-    type Then<Next> = BeforeRequestCons<Next, BeforeRequestNil> where Next: BeforeRequest<Req>;
+    type Then<Next>
+        = BeforeRequestCons<Next, BeforeRequestNil>
+    where
+        Next: BeforeRequest<Req>;
 
     fn then<Next: BeforeRequest<Req>>(self, next: Next) -> Self::Then<Next> {
         BeforeRequestCons(next, BeforeRequestNil)


### PR DESCRIPTION
Generated by running `cargo fmt`.

See https://github.com/google/tarpc/pull/515#issuecomment-2755507577 for the failure without this change.
https://github.com/google/tarpc/actions/runs/14090447232/job/39469379619?pr=515