### PR TITLE
Clippy

### DIFF
--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -532,7 +532,7 @@ struct ServiceGenerator<'a> {
     warnings: &'a [TokenStream2],
 }
 
-impl<'a> ServiceGenerator<'a> {
+impl ServiceGenerator<'_> {
     fn trait_service(&self) -> TokenStream2 {
         let &Self {
             attrs,
@@ -808,7 +808,7 @@ impl<'a> ServiceGenerator<'a> {
     }
 }
 
-impl<'a> ToTokens for ServiceGenerator<'a> {
+impl ToTokens for ServiceGenerator<'_> {
     fn to_tokens(&self, output: &mut TokenStream2) {
         output.extend(vec![
             self.trait_service(),

--- a/tarpc/examples/tracing.rs
+++ b/tarpc/examples/tracing.rs
@@ -4,6 +4,8 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+#![allow(clippy::type_complexity)]
+
 use crate::{
     add::{Add as AddService, AddStub},
     double::Double as DoubleService,


### PR DESCRIPTION
A clippy CI job blocked https://github.com/google/tarpc/pull/515 from being merged.

```console
warning: the following explicit lifetimes could be elided: 'a
   --> plugins/src/lib.rs:535:6
    |
535 | impl<'a> ServiceGenerator<'a> {
    |      ^^                   ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
    = note: `#[warn(clippy::needless_lifetimes)]` on by default
help: elide the lifetimes
    |
535 - impl<'a> ServiceGenerator<'a> {
535 + impl ServiceGenerator<'_> {
    |

warning: the following explicit lifetimes could be elided: 'a
   --> plugins/src/lib.rs:811:6
    |
811 | impl<'a> ToTokens for ServiceGenerator<'a> {
    |      ^^                                ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
811 - impl<'a> ToTokens for ServiceGenerator<'a> {
811 + impl ToTokens for ServiceGenerator<'_> {
    |

warning: very complex type used. Consider factoring parts into `type` definitions
   --> tarpc/examples/tracing.rs:123:6
    |
123 |   ) -> retry::Retry<
    |  ______^
124 | |     impl Fn(&Result<Resp, RpcError>, u32) -> bool + Clone,
125 | |     load_balance::RoundRobin<client::Channel<Arc<Req>, Resp>>,
126 | | >
    | |_^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity
    = note: `#[warn(clippy::type_complexity)]` on by default
```