### PR TITLE
Fix clippy uninlined format args

### DIFF
--- a/tarpc/examples/tls_over_tcp.rs
+++ b/tarpc/examples/tls_over_tcp.rs
@@ -69,7 +69,7 @@ pub fn load_private_key(key: &str) -> rustls::pki_types::PrivateKeyDer {
             _ => continue,
         }
     }
-    panic!("no keys found in {:?} (encrypted keys not supported)", key);
+    panic!("no keys found in {key:?} (encrypted keys not supported)");
 }
 
 async fn spawn(fut: impl Future<Output = ()> + Send + 'static) {
@@ -96,7 +96,7 @@ async fn main() -> anyhow::Result<()> {
         client_auth_roots.into(),
     )
     .build()
-    .map_err(|err| io::Error::new(io::ErrorKind::Other, format!("{}", err)))
+    .map_err(|err| io::Error::new(io::ErrorKind::Other, format!("{err}")))
     .unwrap();
     // ------------- server side client_auth cert loading end
 

--- a/tarpc/src/server.rs
+++ b/tarpc/src/server.rs
@@ -1298,7 +1298,7 @@ mod tests {
 
         let request = match requests.as_mut().poll_next(&mut noop_context()) {
             Poll::Ready(Some(Ok(request))) => request,
-            result => panic!("Unexpected result: {:?}", result),
+            result => panic!("Unexpected result: {result:?}"),
         };
         drop(request);
 
@@ -1318,7 +1318,7 @@ mod tests {
 
         let request = match requests.as_mut().poll_next(&mut noop_context()) {
             Poll::Ready(Some(Ok(request))) => request,
-            result => panic!("Unexpected result: {:?}", result),
+            result => panic!("Unexpected result: {result:?}"),
         };
         request.execute(serve(|_, _| async { Ok(()) })).await;
         assert!(requests


### PR DESCRIPTION
Fix clippy lints that showed up in CI for #527, but seem unrelated.