### PR TITLE
Use specific names instead of Default

### DIFF
--- a/tarpc/examples/custom_transport.rs
+++ b/tarpc/examples/custom_transport.rs
@@ -5,6 +5,7 @@
 // https://opensource.org/licenses/MIT.
 
 use futures::prelude::*;
+use tarpc::client;
 use tarpc::context::Context;
 use tarpc::serde_transport as transport;
 use tarpc::server::{BaseChannel, Channel};
@@ -50,7 +51,7 @@ async fn main() -> anyhow::Result<()> {
 
     let conn = UnixStream::connect(bind_addr).await?;
     let transport = transport::new(codec_builder.new_framed(conn), Bincode::default());
-    PingServiceClient::new(Default::default(), transport)
+    PingServiceClient::new(client::Config::default(), transport)
         .spawn()
         .ping(tarpc::context::current())
         .await?;

--- a/tarpc/examples/tls_over_tcp.rs
+++ b/tarpc/examples/tls_over_tcp.rs
@@ -18,6 +18,7 @@ use tokio_rustls::rustls::{
 };
 use tokio_rustls::{TlsAcceptor, TlsConnector};
 
+use tarpc::client;
 use tarpc::context::Context;
 use tarpc::serde_transport as transport;
 use tarpc::server::{BaseChannel, Channel};
@@ -144,7 +145,7 @@ async fn main() -> anyhow::Result<()> {
     let stream = connector.connect(domain, stream).await?;
 
     let transport = transport::new(codec_builder.new_framed(stream), Bincode::default());
-    let answer = PingServiceClient::new(Default::default(), transport)
+    let answer = PingServiceClient::new(client::Config::default(), transport)
         .spawn()
         .ping(tarpc::context::current())
         .await?;

--- a/tarpc/src/client/in_flight_requests.rs
+++ b/tarpc/src/client/in_flight_requests.rs
@@ -21,8 +21,8 @@ pub struct InFlightRequests<Resp> {
 impl<Resp> Default for InFlightRequests<Resp> {
     fn default() -> Self {
         Self {
-            request_data: Default::default(),
-            deadlines: Default::default(),
+            request_data: FnvHashMap::default(),
+            deadlines: DelayQueue::default(),
         }
     }
 }

--- a/tarpc/src/client/stub/load_balance.rs
+++ b/tarpc/src/client/stub/load_balance.rs
@@ -66,7 +66,7 @@ mod round_robin {
             pub fn new(elements: Vec<T>) -> Self {
                 Self(Arc::new(State {
                     elements,
-                    next: Default::default(),
+                    next: AtomicUsize::new(0),
                 }))
             }
 

--- a/tarpc/src/server/testing.rs
+++ b/tarpc/src/server/testing.rs
@@ -94,7 +94,7 @@ impl<Req, Resp> FakeChannel<io::Result<TrackedRequest<Req>>, Response<Resp>> {
             request: Request {
                 context: context::Context {
                     deadline: Instant::now(),
-                    trace_context: Default::default(),
+                    trace_context: crate::trace::Context::default(),
                 },
                 id,
                 message,
@@ -114,10 +114,10 @@ impl FakeChannel<(), ()> {
     pub fn default<Req, Resp>() -> FakeChannel<io::Result<TrackedRequest<Req>>, Response<Resp>> {
         let (request_cancellation, canceled_requests) = cancellations();
         FakeChannel {
-            stream: Default::default(),
-            sink: Default::default(),
-            config: Default::default(),
-            in_flight_requests: Default::default(),
+            stream: VecDeque::default(),
+            sink: VecDeque::default(),
+            config: Config::default(),
+            in_flight_requests: super::in_flight_requests::InFlightRequests::default(),
             request_cancellation,
             canceled_requests,
         }


### PR DESCRIPTION
Make code easier to read (especially where `Default::default()` is `client::Config` inside generated code and cmd-click does not help).