### PR TITLE
Add optional Apache Fory codec

### DIFF
--- a/tarpc/Cargo.toml
+++ b/tarpc/Cargo.toml
@@ -120,3 +120,7 @@ required-features = ["serde-transport"]
 [[test]]
 name = "dataservice"
 required-features = ["serde-transport", "tcp"]
+
+[[test]]
+name = "fory_envelope"
+required-features = ["fory"]

--- a/tarpc/Cargo.toml
+++ b/tarpc/Cargo.toml
@@ -126,3 +126,7 @@ required-features = ["serde-transport", "tcp"]
 [[test]]
 name = "fory_envelope"
 required-features = ["serde-transport-fory"]
+
+[[test]]
+name = "fory_transport"
+required-features = ["serde-transport-fory", "tcp"]

--- a/tarpc/Cargo.toml
+++ b/tarpc/Cargo.toml
@@ -130,3 +130,7 @@ required-features = ["serde-transport-fory"]
 [[test]]
 name = "fory_transport"
 required-features = ["serde-transport-fory", "tcp"]
+
+[[test]]
+name = "codec_parity"
+required-features = ["serde-transport-fory"]

--- a/tarpc/Cargo.toml
+++ b/tarpc/Cargo.toml
@@ -24,6 +24,8 @@ tokio1 = ["tokio/rt"]
 serde-transport = ["serde1", "tokio1", "tokio-serde", "tokio-util/codec"]
 serde-transport-json = ["serde-transport", "tokio-serde/json"]
 serde-transport-bincode = ["serde-transport", "tokio-serde/bincode"]
+fory = ["dep:fory"]
+serde-transport-fory = ["serde-transport", "fory", "dep:tokio-serde-fory"]
 tcp = ["tokio/net"]
 unix = ["tokio/net"]
 
@@ -53,6 +55,8 @@ thiserror = "2.0"
 tokio = { version = "1", features = ["time"] }
 tokio-util = { version = "0.7", features = ["time"] }
 tokio-serde = { optional = true, version = "0.9" }
+fory = { version = "0.17", optional = true }
+tokio-serde-fory = { path = "../../tokio-serde-fory", optional = true }
 tracing = { version = "0.1", default-features = false, features = [
     "attributes",
     "log",

--- a/tarpc/Cargo.toml
+++ b/tarpc/Cargo.toml
@@ -24,7 +24,7 @@ tokio1 = ["tokio/rt"]
 serde-transport = ["serde1", "tokio1", "tokio-serde", "tokio-util/codec"]
 serde-transport-json = ["serde-transport", "tokio-serde/json"]
 serde-transport-bincode = ["serde-transport", "tokio-serde/bincode"]
-fory = ["dep:fory"]
+fory = ["dep:fory", "dep:fory-core"]
 serde-transport-fory = ["serde-transport", "fory", "dep:tokio-serde-fory"]
 tcp = ["tokio/net"]
 unix = ["tokio/net"]
@@ -56,6 +56,7 @@ tokio = { version = "1", features = ["time"] }
 tokio-util = { version = "0.7", features = ["time"] }
 tokio-serde = { optional = true, version = "0.9" }
 fory = { version = "0.17", optional = true }
+fory-core = { version = "0.17", optional = true }
 tokio-serde-fory = { path = "../../tokio-serde-fory", optional = true }
 tracing = { version = "0.1", default-features = false, features = [
     "attributes",
@@ -66,6 +67,7 @@ opentelemetry = { version = "0.31", default-features = false }
 opentelemetry-semantic-conventions = "0.31"
 
 [dev-dependencies]
+fory-core = "0.17"
 anyhow = "1.0"
 assert_matches = "1.5"
 bincode = { version = "2.0", features = ["serde"] }
@@ -123,4 +125,4 @@ required-features = ["serde-transport", "tcp"]
 
 [[test]]
 name = "fory_envelope"
-required-features = ["fory"]
+required-features = ["serde-transport-fory"]

--- a/tarpc/src/serde_transport.rs
+++ b/tarpc/src/serde_transport.rs
@@ -12,6 +12,10 @@
 #[path = "serde_transport/fory_envelope.rs"]
 pub mod fory_envelope;
 
+#[cfg(feature = "serde-transport-fory")]
+#[path = "serde_transport/fory.rs"]
+pub mod fory;
+
 use futures::{prelude::*, task::*};
 use pin_project::pin_project;
 use serde::{Deserialize, Serialize};

--- a/tarpc/src/serde_transport.rs
+++ b/tarpc/src/serde_transport.rs
@@ -8,6 +8,10 @@
 
 #![deny(missing_docs)]
 
+#[cfg(feature = "serde-transport-fory")]
+#[path = "serde_transport/fory_envelope.rs"]
+pub mod fory_envelope;
+
 use futures::{prelude::*, task::*};
 use pin_project::pin_project;
 use serde::{Deserialize, Serialize};

--- a/tarpc/src/serde_transport/fory.rs
+++ b/tarpc/src/serde_transport/fory.rs
@@ -266,7 +266,7 @@ mod tcp {
             listener,
             fory,
             local_addr,
-            config: length_delimited::Builder::new(),
+            config: *length_delimited::Builder::new().max_frame_length(usize::MAX / 2),
             _marker: PhantomData,
         })
     }

--- a/tarpc/src/serde_transport/fory.rs
+++ b/tarpc/src/serde_transport/fory.rs
@@ -1,0 +1,308 @@
+// Copyright 2018 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! TCP transport using Apache Fory codec.
+//!
+//! Mirrors [`crate::serde_transport::tcp`] but serializes tarpc envelope types
+//! via [`fory`] instead of JSON/bincode. Requires the `serde-transport-fory`
+//! and `tcp` features.
+//!
+//! # Quick start
+//!
+//! ```no_run
+//! # #[cfg(all(feature = "serde-transport-fory", feature = "tcp"))]
+//! # async fn example() -> std::io::Result<()> {
+//! use fory::Fory;
+//! use std::sync::Arc;
+//! use tarpc::serde_transport::fory as fory_transport;
+//!
+//! let fory = Arc::new(Fory::default());
+//!
+//! // Server side
+//! let incoming = fory_transport::listen::<_, String, String>("127.0.0.1:0", fory.clone()).await?;
+//! let addr = incoming.local_addr();
+//!
+//! // Client side
+//! let transport = fory_transport::connect::<_, String, String>(addr, fory).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Type registration
+//!
+//! The fory codec requires all types that cross the wire to be registered in the
+//! same [`fory::Fory`] instance on both sides with identical numeric IDs. At a
+//! minimum register the envelope wrapper types from
+//! [`crate::serde_transport::fory_envelope`] **plus** your own `Req`/`Resp` types
+//! (unless they are built-in primitive types that fory handles natively).
+
+use super::fory_envelope::{ForyClientMessage, ForyResponse};
+use crate::{ClientMessage, Response};
+use fory::Fory;
+use std::{io, marker::PhantomData, pin::Pin, sync::Arc};
+use tokio_util::bytes::{Bytes, BytesMut};
+
+// The parent module (serde_transport) exposes `new` and `Transport`.
+use crate::serde_transport::{self, Transport};
+
+// ---------------------------------------------------------------------------
+// ForyEnvelopeCodec
+// ---------------------------------------------------------------------------
+
+/// Codec that converts tarpc's native envelope types ↔ fory wrapper types at
+/// the wire boundary.
+///
+/// `Req` is the user-defined request message type; `Resp` is the response
+/// message type. The codec works symmetrically on both client and server sides:
+///
+/// - **Client side**: `Serializer<ClientMessage<Req>>` + `Deserializer<Response<Resp>>`
+/// - **Server side**: `Serializer<Response<Resp>>` + `Deserializer<ClientMessage<Req>>`
+pub struct ForyEnvelopeCodec<Req, Resp> {
+    fory: Arc<Fory>,
+    _marker: PhantomData<(Req, Resp)>,
+}
+
+impl<Req, Resp> ForyEnvelopeCodec<Req, Resp> {
+    /// Create a new codec sharing the given [`Fory`] registry.
+    pub fn new(fory: Arc<Fory>) -> Self {
+        Self { fory, _marker: PhantomData }
+    }
+}
+
+impl<Req, Resp> Clone for ForyEnvelopeCodec<Req, Resp> {
+    fn clone(&self) -> Self {
+        Self { fory: self.fory.clone(), _marker: PhantomData }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Client side: send ClientMessage<Req>
+// ---------------------------------------------------------------------------
+
+impl<Req, Resp> tokio_serde::Serializer<ClientMessage<Req>> for ForyEnvelopeCodec<Req, Resp>
+where
+    Req: fory::Serializer + fory::ForyDefault + Clone + Send + 'static,
+{
+    type Error = io::Error;
+
+    fn serialize(
+        self: Pin<&mut Self>,
+        item: &ClientMessage<Req>,
+    ) -> Result<Bytes, Self::Error> {
+        let wrapper = ForyClientMessage::<Req>::from(item);
+        self.fory
+            .serialize(&wrapper)
+            .map(Bytes::from)
+            .map_err(|e: fory::Error| {
+                io::Error::new(io::ErrorKind::InvalidData, e.to_string())
+            })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Client side: receive Response<Resp>
+// ---------------------------------------------------------------------------
+
+impl<Req, Resp> tokio_serde::Deserializer<Response<Resp>> for ForyEnvelopeCodec<Req, Resp>
+where
+    Resp: fory::Serializer + fory::ForyDefault + Send + 'static,
+{
+    type Error = io::Error;
+
+    fn deserialize(
+        self: Pin<&mut Self>,
+        src: &BytesMut,
+    ) -> Result<Response<Resp>, Self::Error> {
+        let wrapper: ForyResponse<Resp> = self
+            .fory
+            .deserialize(src.as_ref())
+            .map_err(|e: fory::Error| {
+                io::Error::new(io::ErrorKind::InvalidData, e.to_string())
+            })?;
+        Ok(Response::from(wrapper))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Server side: send Response<Resp>
+// ---------------------------------------------------------------------------
+
+impl<Req, Resp> tokio_serde::Serializer<Response<Resp>> for ForyEnvelopeCodec<Req, Resp>
+where
+    Resp: fory::Serializer + fory::ForyDefault + Clone + Send + 'static,
+{
+    type Error = io::Error;
+
+    fn serialize(
+        self: Pin<&mut Self>,
+        item: &Response<Resp>,
+    ) -> Result<Bytes, Self::Error> {
+        let wrapper = ForyResponse::<Resp>::from(item);
+        self.fory
+            .serialize(&wrapper)
+            .map(Bytes::from)
+            .map_err(|e: fory::Error| {
+                io::Error::new(io::ErrorKind::InvalidData, e.to_string())
+            })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Server side: receive ClientMessage<Req>
+// ---------------------------------------------------------------------------
+
+impl<Req, Resp> tokio_serde::Deserializer<ClientMessage<Req>> for ForyEnvelopeCodec<Req, Resp>
+where
+    Req: fory::Serializer + fory::ForyDefault + Send + 'static,
+{
+    type Error = io::Error;
+
+    fn deserialize(
+        self: Pin<&mut Self>,
+        src: &BytesMut,
+    ) -> Result<ClientMessage<Req>, Self::Error> {
+        let wrapper: ForyClientMessage<Req> = self
+            .fory
+            .deserialize(src.as_ref())
+            .map_err(|e: fory::Error| {
+                io::Error::new(io::ErrorKind::InvalidData, e.to_string())
+            })?;
+        Ok(ClientMessage::from(wrapper))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TCP support (requires `tcp` feature)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "tcp")]
+pub use tcp::{Incoming, connect, listen};
+
+#[cfg(feature = "tcp")]
+mod tcp {
+    use super::*;
+    use futures::ready;
+    use pin_project::pin_project;
+    use std::net::SocketAddr;
+    use tokio::net::{TcpListener, TcpStream, ToSocketAddrs};
+    use tokio_util::codec::length_delimited;
+
+    // -----------------------------------------------------------------------
+    // connect
+    // -----------------------------------------------------------------------
+
+    /// Connects to `addr` and returns a client-side fory transport.
+    ///
+    /// The transport sinks `ClientMessage<Req>` and streams `Response<Resp>`.
+    pub async fn connect<A, Req, Resp>(
+        addr: A,
+        fory: Arc<Fory>,
+    ) -> io::Result<
+        Transport<TcpStream, Response<Resp>, ClientMessage<Req>, ForyEnvelopeCodec<Req, Resp>>,
+    >
+    where
+        A: ToSocketAddrs,
+        Req: fory::Serializer + fory::ForyDefault + Clone + Send + 'static,
+        Resp: fory::Serializer + fory::ForyDefault + Send + 'static,
+        // serde bounds required by Transport's Stream/Sink impls
+        ClientMessage<Req>: serde::Serialize,
+        Response<Resp>: for<'de> serde::Deserialize<'de>,
+    {
+        let stream = TcpStream::connect(addr).await?;
+        let framed = length_delimited::Builder::new()
+            .max_frame_length(usize::MAX / 2)
+            .new_framed(stream);
+        Ok(serde_transport::new(framed, ForyEnvelopeCodec::new(fory)))
+    }
+
+    // -----------------------------------------------------------------------
+    // listen / Incoming
+    // -----------------------------------------------------------------------
+
+    /// A [`TcpListener`] that wraps accepted connections in fory-encoded
+    /// server-side transports.
+    #[pin_project]
+    pub struct Incoming<Req, Resp> {
+        #[pin]
+        listener: TcpListener,
+        fory: Arc<Fory>,
+        local_addr: SocketAddr,
+        config: length_delimited::Builder,
+        _marker: PhantomData<(Req, Resp)>,
+    }
+
+    impl<Req, Resp> Incoming<Req, Resp> {
+        /// Returns the address being listened on.
+        pub fn local_addr(&self) -> SocketAddr {
+            self.local_addr
+        }
+
+        /// Returns an immutable reference to the length-delimited codec's config.
+        pub fn config(&self) -> &length_delimited::Builder {
+            &self.config
+        }
+
+        /// Returns a mutable reference to the length-delimited codec's config.
+        pub fn config_mut(&mut self) -> &mut length_delimited::Builder {
+            &mut self.config
+        }
+    }
+
+    /// Listens on `addr` and returns an [`Incoming`] stream of server-side
+    /// transports.
+    ///
+    /// Each accepted transport sinks `Response<Resp>` and streams
+    /// `ClientMessage<Req>`.
+    pub async fn listen<A, Req, Resp>(addr: A, fory: Arc<Fory>) -> io::Result<Incoming<Req, Resp>>
+    where
+        A: ToSocketAddrs,
+    {
+        let listener = TcpListener::bind(addr).await?;
+        let local_addr = listener.local_addr()?;
+        Ok(Incoming {
+            listener,
+            fory,
+            local_addr,
+            config: length_delimited::Builder::new(),
+            _marker: PhantomData,
+        })
+    }
+
+    impl<Req, Resp> futures::stream::Stream for Incoming<Req, Resp>
+    where
+        Req: fory::Serializer + fory::ForyDefault + Send + 'static,
+        Resp: fory::Serializer + fory::ForyDefault + Clone + Send + 'static,
+        // serde bounds required by Transport's Stream/Sink impls
+        Response<Resp>: serde::Serialize,
+        ClientMessage<Req>: for<'de> serde::Deserialize<'de>,
+    {
+        type Item = io::Result<
+            Transport<
+                TcpStream,
+                ClientMessage<Req>,
+                Response<Resp>,
+                ForyEnvelopeCodec<Req, Resp>,
+            >,
+        >;
+
+        fn poll_next(
+            mut self: Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Option<Self::Item>> {
+            let accept_result = ready!(self.as_mut().project().listener.poll_accept(cx));
+            let (stream, _peer) = match accept_result {
+                Ok(pair) => pair,
+                Err(e) => return std::task::Poll::Ready(Some(Err(e))),
+            };
+            let framed = self.config.new_framed(stream);
+            let transport = serde_transport::new(
+                framed,
+                ForyEnvelopeCodec::<Req, Resp>::new(self.fory.clone()),
+            );
+            std::task::Poll::Ready(Some(Ok(transport)))
+        }
+    }
+}

--- a/tarpc/src/serde_transport/fory_envelope.rs
+++ b/tarpc/src/serde_transport/fory_envelope.rs
@@ -1,0 +1,350 @@
+// Copyright 2018 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Fory-friendly envelope types for the `serde_transport::fory` codec path.
+//!
+//! These mirror tarpc's native `ClientMessage<T>`, `Response<T>`, `Request<T>`,
+//! and `ServerError` types. The native types are unsuitable for fory because
+//! they reference `std::result::Result`, `std::time::Instant`, and
+//! `std::io::ErrorKind` — none of which fory-core 0.17 provides
+//! `fory::Serializer` impls for.
+//!
+//! Conversions between native and wrapper types are field-by-field and lossless
+//! for the round-trip path the transport actually uses. Schema drift is
+//! caught by the codec parity test (Task 3.5).
+//!
+//! ## `io::ErrorKind` wire encoding
+//!
+//! The u32 discriminants match tarpc's own serde encoding in `util/serde.rs`:
+//!
+//! | u32 | io::ErrorKind        |
+//! |-----|----------------------|
+//! |   0 | NotFound             |
+//! |   1 | PermissionDenied     |
+//! |   2 | ConnectionRefused    |
+//! |   3 | ConnectionReset      |
+//! |   4 | ConnectionAborted    |
+//! |   5 | NotConnected         |
+//! |   6 | AddrInUse            |
+//! |   7 | AddrNotAvailable     |
+//! |   8 | BrokenPipe           |
+//! |   9 | AlreadyExists        |
+//! |  10 | WouldBlock           |
+//! |  11 | InvalidInput         |
+//! |  12 | InvalidData          |
+//! |  13 | TimedOut             |
+//! |  14 | WriteZero            |
+//! |  15 | Interrupted          |
+//! |  16 | Other                |
+//! |  17 | UnexpectedEof        |
+//! |  _  | Other (fallback)     |
+//!
+//! ## Deadline encoding
+//!
+//! `context::Context.deadline` is a `std::time::Instant` (monotonic, local-only).
+//! For the wire we encode it as the number of nanoseconds remaining from `Instant::now()`
+//! at serialize time (i.e. `deadline.saturating_duration_since(now).as_nanos() as u64`).
+//! A value of 0 means "already expired or no deadline". The receiver reconstructs
+//! `Instant::now() + Duration::from_nanos(remaining_ns)`.
+
+use std::io;
+use std::time::{Duration, Instant};
+
+use fory::{ForyDefault, ForyObject, Serializer};
+
+use crate::{ClientMessage, Request, Response, ServerError, context, trace};
+
+// ---------------------------------------------------------------------------
+// Wrapper types
+// ---------------------------------------------------------------------------
+
+/// Fory-serializable mirror of `trace::Context`.
+#[derive(Debug, Clone, ForyObject)]
+pub struct ForyTraceContext {
+    /// Raw u128 bits of the `TraceId`.
+    pub trace_id: u128,
+    /// Raw u64 bits of the `SpanId`.
+    pub span_id: u64,
+    /// Sampling decision: 0 = Unsampled, 1 = Sampled.
+    pub sampling: u8,
+}
+
+/// Fory-serializable mirror of `ServerError`.
+///
+/// `kind` is encoded as a u32 per the table in the module-level docs.
+#[derive(Debug, Clone, ForyObject)]
+pub struct ForyServerError {
+    /// io::ErrorKind discriminant value (see module docs for mapping).
+    pub kind: u32,
+    /// Human-readable error detail.
+    pub detail: String,
+}
+
+/// Fory-serializable analog of `Result<T, ServerError>`.
+///
+/// fory-core 0.17 has no `Serializer` impl for `std::result::Result`, so we
+/// define a dedicated two-variant enum.
+#[derive(Debug, Clone, ForyObject)]
+pub enum ForyResult<T: Serializer + ForyDefault + 'static> {
+    /// Successful response payload.
+    Ok(T),
+    /// Server-side error.
+    Err(ForyServerError),
+}
+
+/// Fory-serializable mirror of `Request<T>`.
+///
+/// `context::Context.deadline` (an `Instant`) is replaced by `deadline_ns`:
+/// nanoseconds remaining from the point of serialization. See module docs.
+#[derive(Debug, Clone, ForyObject)]
+pub struct ForyRequest<T: Serializer + ForyDefault + 'static> {
+    /// Request ID — unique within a single channel.
+    pub id: u64,
+    /// Trace context (mirrors `context.trace_context`).
+    pub trace: ForyTraceContext,
+    /// Deadline as nanoseconds remaining (from serialize time).  0 = expired / no deadline.
+    pub deadline_ns: u64,
+    /// Request body.
+    pub message: T,
+}
+
+/// Fory-serializable mirror of `Response<T>`.
+#[derive(Debug, Clone, ForyObject)]
+pub struct ForyResponse<T: Serializer + ForyDefault + 'static> {
+    /// ID of the request this is responding to.
+    pub request_id: u64,
+    /// Response body or server error.
+    pub message: ForyResult<T>,
+}
+
+/// Fory-serializable mirror of `ClientMessage<T>`.
+#[derive(Debug, Clone, ForyObject)]
+pub enum ForyClientMessage<T: Serializer + ForyDefault + 'static> {
+    /// A new request from the client.
+    Request(ForyRequest<T>),
+    /// Cancellation of an in-flight request.
+    Cancel {
+        /// Trace context associated with the original request.
+        trace: ForyTraceContext,
+        /// ID of the request to cancel.
+        request_id: u64,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Conversions: native → wrapper
+// ---------------------------------------------------------------------------
+
+impl From<trace::SamplingDecision> for u8 {
+    fn from(d: trace::SamplingDecision) -> u8 {
+        match d {
+            trace::SamplingDecision::Sampled => 1,
+            trace::SamplingDecision::Unsampled => 0,
+        }
+    }
+}
+
+impl From<u8> for trace::SamplingDecision {
+    fn from(v: u8) -> trace::SamplingDecision {
+        if v == 1 {
+            trace::SamplingDecision::Sampled
+        } else {
+            trace::SamplingDecision::Unsampled
+        }
+    }
+}
+
+impl From<&trace::Context> for ForyTraceContext {
+    fn from(tc: &trace::Context) -> Self {
+        ForyTraceContext {
+            trace_id: u128::from(tc.trace_id),
+            span_id: u64::from(tc.span_id),
+            sampling: u8::from(tc.sampling_decision),
+        }
+    }
+}
+
+impl From<ForyTraceContext> for trace::Context {
+    fn from(ftc: ForyTraceContext) -> Self {
+        trace::Context {
+            trace_id: trace::TraceId::from(ftc.trace_id),
+            span_id: trace::SpanId::from(ftc.span_id),
+            sampling_decision: trace::SamplingDecision::from(ftc.sampling),
+        }
+    }
+}
+
+/// Encode `io::ErrorKind` as u32 using the same table as `util::serde`.
+pub fn error_kind_to_u32(kind: io::ErrorKind) -> u32 {
+    use io::ErrorKind::*;
+    match kind {
+        NotFound => 0,
+        PermissionDenied => 1,
+        ConnectionRefused => 2,
+        ConnectionReset => 3,
+        ConnectionAborted => 4,
+        NotConnected => 5,
+        AddrInUse => 6,
+        AddrNotAvailable => 7,
+        BrokenPipe => 8,
+        AlreadyExists => 9,
+        WouldBlock => 10,
+        InvalidInput => 11,
+        InvalidData => 12,
+        TimedOut => 13,
+        WriteZero => 14,
+        Interrupted => 15,
+        Other => 16,
+        UnexpectedEof => 17,
+        _ => 16, // map unknown variants to Other
+    }
+}
+
+/// Decode u32 back to `io::ErrorKind`.
+pub fn u32_to_error_kind(v: u32) -> io::ErrorKind {
+    use io::ErrorKind::*;
+    match v {
+        0 => NotFound,
+        1 => PermissionDenied,
+        2 => ConnectionRefused,
+        3 => ConnectionReset,
+        4 => ConnectionAborted,
+        5 => NotConnected,
+        6 => AddrInUse,
+        7 => AddrNotAvailable,
+        8 => BrokenPipe,
+        9 => AlreadyExists,
+        10 => WouldBlock,
+        11 => InvalidInput,
+        12 => InvalidData,
+        13 => TimedOut,
+        14 => WriteZero,
+        15 => Interrupted,
+        16 => Other,
+        17 => UnexpectedEof,
+        _ => Other,
+    }
+}
+
+impl From<&ServerError> for ForyServerError {
+    fn from(se: &ServerError) -> Self {
+        ForyServerError {
+            kind: error_kind_to_u32(se.kind),
+            detail: se.detail.clone(),
+        }
+    }
+}
+
+impl From<ForyServerError> for ServerError {
+    fn from(fse: ForyServerError) -> Self {
+        ServerError {
+            kind: u32_to_error_kind(fse.kind),
+            detail: fse.detail,
+        }
+    }
+}
+
+impl<T: Serializer + ForyDefault + Clone + 'static> From<&Request<T>> for ForyRequest<T> {
+    fn from(req: &Request<T>) -> Self {
+        let now = Instant::now();
+        let deadline_ns = req
+            .context
+            .deadline
+            .checked_duration_since(now)
+            .map(|d| d.as_nanos().min(u64::MAX as u128) as u64)
+            .unwrap_or(0);
+        ForyRequest {
+            id: req.id,
+            trace: ForyTraceContext::from(&req.context.trace_context),
+            deadline_ns,
+            message: req.message.clone(),
+        }
+    }
+}
+
+impl<T: Serializer + ForyDefault + 'static> From<ForyRequest<T>> for Request<T> {
+    fn from(fr: ForyRequest<T>) -> Self {
+        let deadline = Instant::now() + Duration::from_nanos(fr.deadline_ns);
+        Request {
+            context: context::Context {
+                deadline,
+                trace_context: trace::Context::from(fr.trace),
+            },
+            id: fr.id,
+            message: fr.message,
+        }
+    }
+}
+
+impl<T: Serializer + ForyDefault + 'static> From<Result<T, ServerError>> for ForyResult<T> {
+    fn from(r: Result<T, ServerError>) -> Self {
+        match r {
+            Ok(v) => ForyResult::Ok(v),
+            Err(e) => ForyResult::Err(ForyServerError::from(&e)),
+        }
+    }
+}
+
+impl<T: Serializer + ForyDefault + 'static> From<ForyResult<T>> for Result<T, ServerError> {
+    fn from(fr: ForyResult<T>) -> Self {
+        match fr {
+            ForyResult::Ok(v) => Ok(v),
+            ForyResult::Err(e) => Err(ServerError::from(e)),
+        }
+    }
+}
+
+impl<T: Serializer + ForyDefault + 'static> From<&Response<T>> for ForyResponse<T>
+where
+    T: Clone,
+{
+    fn from(resp: &Response<T>) -> Self {
+        ForyResponse {
+            request_id: resp.request_id,
+            message: ForyResult::from(resp.message.clone()),
+        }
+    }
+}
+
+impl<T: Serializer + ForyDefault + 'static> From<ForyResponse<T>> for Response<T> {
+    fn from(fr: ForyResponse<T>) -> Self {
+        Response {
+            request_id: fr.request_id,
+            message: Result::from(fr.message),
+        }
+    }
+}
+
+impl<T: Serializer + ForyDefault + Clone + 'static> From<&ClientMessage<T>>
+    for ForyClientMessage<T>
+{
+    fn from(msg: &ClientMessage<T>) -> Self {
+        match msg {
+            ClientMessage::Request(req) => {
+                ForyClientMessage::Request(ForyRequest::from(req))
+            }
+            ClientMessage::Cancel {
+                trace_context,
+                request_id,
+            } => ForyClientMessage::Cancel {
+                trace: ForyTraceContext::from(trace_context),
+                request_id: *request_id,
+            },
+        }
+    }
+}
+
+impl<T: Serializer + ForyDefault + 'static> From<ForyClientMessage<T>> for ClientMessage<T> {
+    fn from(fm: ForyClientMessage<T>) -> Self {
+        match fm {
+            ForyClientMessage::Request(fr) => ClientMessage::Request(Request::from(fr)),
+            ForyClientMessage::Cancel { trace, request_id } => ClientMessage::Cancel {
+                trace_context: trace::Context::from(trace),
+                request_id,
+            },
+        }
+    }
+}

--- a/tarpc/tests/codec_parity.rs
+++ b/tarpc/tests/codec_parity.rs
@@ -1,0 +1,267 @@
+// Copyright 2018 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Codec parity / drift guard: round-trip native tarpc envelope types through
+//! the fory wrapper types and back, verifying field-level fidelity.
+//!
+//! Each test exercises the full path:
+//!   `native_msg → ForyXxx → fory bytes → ForyXxx → native_msg'`
+//! and asserts that `native_msg' ≈ native_msg` (modulo intentionally lossy
+//! conversions, e.g. `Instant → relative nanos → re-anchored Instant`).
+//!
+//! ## Why no custom `Body` struct?
+//!
+//! The `ForyObject` derive macro assigns a compile-time type index starting
+//! from 0 for each crate.  Registering a user-defined `Body` type (index 0 in
+//! the test crate) alongside `ForyTraceContext` (also index 0 in the tarpc lib
+//! crate) in the same `TypeResolver` would collide.  We avoid this by using
+//! builtin primitive types (`u32`, `String`) as the generic parameter `T`,
+//! because builtin types are registered through `register_internal_serializer`
+//! and do not occupy the compile-time index table.
+
+#![cfg(feature = "serde-transport-fory")]
+
+use fory::Fory;
+use std::time::{Duration, Instant};
+use tarpc::context;
+use tarpc::serde_transport::fory_envelope::{
+    ForyClientMessage, ForyRequest, ForyResponse, ForyResult, ForyServerError, ForyTraceContext,
+};
+use tarpc::trace::{self, SamplingDecision, SpanId, TraceId};
+use tarpc::{ClientMessage, Request, Response, ServerError};
+
+// ---------------------------------------------------------------------------
+// Helper: build a Fory instance with all envelope types registered for u32 T.
+// ---------------------------------------------------------------------------
+
+fn build_fory_u32() -> Fory {
+    let mut fory = Fory::default();
+    fory.register::<ForyTraceContext>(2).unwrap();
+    fory.register::<ForyServerError>(3).unwrap();
+    fory.register::<ForyResult<u32>>(4).unwrap();
+    fory.register::<ForyRequest<u32>>(5).unwrap();
+    fory.register::<ForyResponse<u32>>(6).unwrap();
+    fory.register::<ForyClientMessage<u32>>(7).unwrap();
+    fory
+}
+
+fn build_fory_string() -> Fory {
+    let mut fory = Fory::default();
+    fory.register::<ForyTraceContext>(2).unwrap();
+    fory.register::<ForyServerError>(3).unwrap();
+    fory.register::<ForyResult<String>>(4).unwrap();
+    fory.register::<ForyRequest<String>>(5).unwrap();
+    fory.register::<ForyResponse<String>>(6).unwrap();
+    fory.register::<ForyClientMessage<String>>(7).unwrap();
+    fory
+}
+
+// ---------------------------------------------------------------------------
+// ClientMessage::Request round-trip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn client_message_request_round_trip() {
+    let fory = build_fory_string();
+
+    // Build a native ClientMessage::Request value.
+    let mut ctx = context::current();
+    ctx.deadline = Instant::now() + Duration::from_secs(60);
+    ctx.trace_context = trace::Context {
+        trace_id: TraceId::from(0x1234_5678_9abc_def0_1234_5678_9abc_def0_u128),
+        span_id: SpanId::from(0xdead_beef_cafe_babe_u64),
+        sampling_decision: SamplingDecision::Sampled,
+    };
+
+    let native: ClientMessage<String> = ClientMessage::Request(Request {
+        context: ctx,
+        id: 42,
+        message: "hello".to_string(),
+    });
+
+    // native → wrapper → bytes → wrapper → native
+    let wrapper: ForyClientMessage<String> = (&native).into();
+    let bytes = fory.serialize(&wrapper).unwrap();
+    let decoded_wrapper: ForyClientMessage<String> = fory.deserialize(&bytes).unwrap();
+    let native_again: ClientMessage<String> = decoded_wrapper.into();
+
+    // Verify the user-payload survives.
+    match (&native, &native_again) {
+        (ClientMessage::Request(a), ClientMessage::Request(b)) => {
+            assert_eq!(a.id, b.id);
+            assert_eq!(a.message, b.message);
+            assert_eq!(
+                u128::from(a.context.trace_context.trace_id),
+                u128::from(b.context.trace_context.trace_id)
+            );
+            assert_eq!(
+                u64::from(a.context.trace_context.span_id),
+                u64::from(b.context.trace_context.span_id)
+            );
+            assert_eq!(
+                a.context.trace_context.sampling_decision,
+                b.context.trace_context.sampling_decision
+            );
+            // Deadline is encoded as relative nanos and re-anchored at decode time.
+            // The reconstructed deadline should be within 1 second of the original
+            // (allowing for serialize/deserialize latency).
+            let drift = a
+                .context
+                .deadline
+                .saturating_duration_since(b.context.deadline)
+                .max(b.context.deadline.saturating_duration_since(a.context.deadline));
+            assert!(
+                drift < Duration::from_secs(1),
+                "deadline drift > 1s: {:?}",
+                drift
+            );
+        }
+        _ => panic!("expected Request, got Cancel after round-trip"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ClientMessage::Cancel round-trip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn client_message_cancel_round_trip() {
+    let fory = build_fory_u32();
+
+    let trace_ctx = trace::Context {
+        trace_id: TraceId::from(99_u128),
+        span_id: SpanId::from(100_u64),
+        sampling_decision: SamplingDecision::Unsampled,
+    };
+    let native: ClientMessage<u32> = ClientMessage::Cancel {
+        trace_context: trace_ctx,
+        request_id: 1234,
+    };
+
+    let wrapper: ForyClientMessage<u32> = (&native).into();
+    let bytes = fory.serialize(&wrapper).unwrap();
+    let decoded: ForyClientMessage<u32> = fory.deserialize(&bytes).unwrap();
+    let native_again: ClientMessage<u32> = decoded.into();
+
+    match native_again {
+        ClientMessage::Cancel {
+            trace_context,
+            request_id,
+        } => {
+            assert_eq!(request_id, 1234);
+            assert_eq!(u128::from(trace_context.trace_id), 99_u128);
+            assert_eq!(u64::from(trace_context.span_id), 100_u64);
+            assert_eq!(
+                trace_context.sampling_decision,
+                SamplingDecision::Unsampled
+            );
+        }
+        _ => panic!("expected Cancel"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Response::Ok round-trip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn response_ok_round_trip() {
+    let fory = build_fory_string();
+
+    let native: Response<String> = Response {
+        request_id: 7,
+        message: Ok("ok-payload".to_string()),
+    };
+
+    let wrapper: ForyResponse<String> = (&native).into();
+    let bytes = fory.serialize(&wrapper).unwrap();
+    let decoded: ForyResponse<String> = fory.deserialize(&bytes).unwrap();
+    let native_again: Response<String> = decoded.into();
+
+    assert_eq!(native_again.request_id, 7);
+    assert_eq!(native_again.message.unwrap(), "ok-payload");
+}
+
+// ---------------------------------------------------------------------------
+// Response::Err round-trip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn response_error_round_trip() {
+    let fory = build_fory_u32();
+
+    let native: Response<u32> = Response {
+        request_id: 8,
+        message: Err(ServerError::new(
+            std::io::ErrorKind::NotFound,
+            "missing".to_string(),
+        )),
+    };
+
+    let wrapper: ForyResponse<u32> = (&native).into();
+    let bytes = fory.serialize(&wrapper).unwrap();
+    let decoded: ForyResponse<u32> = fory.deserialize(&bytes).unwrap();
+    let native_again: Response<u32> = decoded.into();
+
+    assert_eq!(native_again.request_id, 8);
+    let err = native_again.message.expect_err("should be Err");
+    assert_eq!(err.kind, std::io::ErrorKind::NotFound);
+    assert_eq!(err.detail, "missing");
+}
+
+// ---------------------------------------------------------------------------
+// Request id + message + trace context field completeness check
+// ---------------------------------------------------------------------------
+
+#[test]
+fn request_all_fields_survive() {
+    let fory = build_fory_u32();
+
+    let mut ctx = context::current();
+    ctx.deadline = Instant::now() + Duration::from_secs(30);
+    ctx.trace_context = trace::Context {
+        trace_id: TraceId::from(0xABCD_EF01_2345_6789_u128),
+        span_id: SpanId::from(0xFEDC_BA98_u64),
+        sampling_decision: SamplingDecision::Sampled,
+    };
+
+    let native: ClientMessage<u32> = ClientMessage::Request(Request {
+        context: ctx,
+        id: 99,
+        message: 42_u32,
+    });
+
+    let wrapper: ForyClientMessage<u32> = (&native).into();
+    let bytes = fory.serialize(&wrapper).unwrap();
+    let decoded: ForyClientMessage<u32> = fory.deserialize(&bytes).unwrap();
+    let native_again: ClientMessage<u32> = decoded.into();
+
+    match native_again {
+        ClientMessage::Request(req) => {
+            assert_eq!(req.id, 99);
+            assert_eq!(req.message, 42_u32);
+            assert_eq!(
+                u128::from(req.context.trace_context.trace_id),
+                0xABCD_EF01_2345_6789_u128
+            );
+            assert_eq!(
+                u64::from(req.context.trace_context.span_id),
+                0xFEDC_BA98_u64
+            );
+            assert_eq!(
+                req.context.trace_context.sampling_decision,
+                SamplingDecision::Sampled
+            );
+            // Deadline should still be in the future and within 30s.
+            let remaining = req.context.deadline.saturating_duration_since(Instant::now());
+            assert!(
+                remaining > Duration::from_secs(28),
+                "remaining deadline too short: {remaining:?}"
+            );
+        }
+        _ => panic!("expected Request variant"),
+    }
+}

--- a/tarpc/tests/fory_envelope.rs
+++ b/tarpc/tests/fory_envelope.rs
@@ -1,0 +1,114 @@
+// Copyright 2018 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! Round-trip test scaffold for ForyObject derives on tarpc envelope types.
+//!
+//! # Status: BLOCKED — see module-level docs.
+//!
+//! ## Inventory of envelope types and blockers
+//!
+//! ### Envelope types in `tarpc/src/lib.rs`
+//!
+//! | Type | Generic | Fields |
+//! |------|---------|--------|
+//! | `ClientMessage<T>` | `T` | `Request(Request<T>)`, `Cancel { trace_context: trace::Context, request_id: u64 }` |
+//! | `Request<T>` | `T` | `context: context::Context`, `id: u64`, `message: T` |
+//! | `Response<T>` | `T` | `request_id: u64`, `message: Result<T, ServerError>` |
+//! | `ServerError` | none | `kind: io::ErrorKind`, `detail: String` |
+//!
+//! ### Sub-types and their serializability
+//!
+//! | Type | Fory-serializable? | Reason |
+//! |------|--------------------|--------|
+//! | `trace::TraceId(u128)` | YES | u128 is serializable |
+//! | `trace::SpanId(u64)` | YES | u64 is serializable |
+//! | `trace::SamplingDecision` | YES | C-style enum, u8-repr |
+//! | `trace::Context` | YES — derivable | all fields are serializable |
+//! | `context::Context` | **NO** | contains `deadline: std::time::Instant` |
+//! | `ServerError` | **NO** | contains `kind: io::ErrorKind` |
+//! | `Result<T, ServerError>` | **NO** | no `impl Serializer for Result<T, E>` in fory-core |
+//!
+//! ### Compiler error (confirming the wall)
+//!
+//! Attempting `#[cfg_attr(feature = "fory", derive(fory::ForyObject))]` on `Request<T>` produces:
+//! ```text
+//! error[E0277]: the trait bound `Instant: fory_core::Serializer` is not satisfied
+//! ```
+//!
+//! Attempting it on `Response<T>` produces:
+//! ```text
+//! error[E0277]: the trait bound `Result<T, ServerError>: fory_core::Serializer` is not satisfied
+//! ```
+//!
+//! ## Cargo.toml changes required (not yet applied — Task 3.2 follow-up)
+//!
+//! ```toml
+//! # in [dependencies]:
+//! fory-core = { version = "0.17", optional = true }
+//!
+//! # in [features]:
+//! fory = ["dep:fory", "dep:fory-core"]
+//!
+//! # in [dev-dependencies]:
+//! fory-core = { version = "0.17" }
+//! ```
+//!
+//! The `fory-derive` macro emits `fory_core::` paths in generated code.
+//! In Rust 2024 edition, transitive crates are not in scope; `fory-core` must be
+//! a direct dependency of any crate using `#[derive(ForyObject)]`.
+//!
+//! ## Resolution path (Task 3.4)
+//!
+//! Define parallel fory-specific envelope types in `tarpc/src/serde_transport/fory.rs`:
+//!
+//! ```rust
+//! #[derive(fory::ForyObject, Debug, PartialEq)]
+//! pub struct ForyTraceContext { pub trace_id: u128, pub span_id: u64, pub sampling: u8 }
+//!
+//! #[derive(fory::ForyObject, Debug, PartialEq)]
+//! pub struct ForyServerError { pub kind: u32, pub detail: String }
+//!
+//! #[derive(fory::ForyObject, Debug, PartialEq)]
+//! pub enum ForyResult<T> { Ok(T), Err(ForyServerError) }
+//!
+//! #[derive(fory::ForyObject, Debug, PartialEq)]
+//! pub struct ForyRequest<T> {
+//!     pub id: u64,
+//!     pub trace: ForyTraceContext,
+//!     pub deadline_ns: u64,   // Instant replaced by relative nanoseconds from now
+//!     pub message: T,
+//! }
+//!
+//! #[derive(fory::ForyObject, Debug, PartialEq)]
+//! pub struct ForyResponse<T> {
+//!     pub request_id: u64,
+//!     pub message: ForyResult<T>,
+//! }
+//!
+//! #[derive(fory::ForyObject, Debug, PartialEq)]
+//! pub enum ForyClientMessage<T> {
+//!     Request(ForyRequest<T>),
+//!     Cancel { trace: ForyTraceContext, request_id: u64 },
+//! }
+//! ```
+//!
+//! The tarpc transport adapter (Task 3.4) converts these to/from native tarpc types
+//! on the wire boundary. `deadline_ns` is re-anchored to a local `Instant::now() + duration`
+//! on the receiving end.
+//!
+//! Once Task 3.4 is complete and Cargo.toml is updated, this test file should be
+//! expanded with full round-trip assertions for all ForyXxx envelope types.
+
+#![cfg(feature = "fory")]
+
+/// Feature-flag smoke test: verifies that `use fory::Fory` is accessible
+/// when the `fory` feature is enabled. Does not exercise envelope types yet.
+/// Full envelope round-trip tests are deferred to Task 3.4.
+#[test]
+fn fory_feature_available() {
+    // If this compiles, the `fory` feature flag wiring is correct.
+    let _fory = fory::Fory::default();
+}

--- a/tarpc/tests/fory_envelope.rs
+++ b/tarpc/tests/fory_envelope.rs
@@ -4,111 +4,353 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-//! Round-trip test scaffold for ForyObject derives on tarpc envelope types.
+//! Round-trip tests for fory-serializable tarpc envelope types.
 //!
-//! # Status: BLOCKED — see module-level docs.
+//! These tests verify that `ForyClientMessage`, `ForyRequest`, `ForyResponse`,
+//! and their helpers can be serialized and deserialized via the fory codec
+//! without data loss. They also exercise the `From`/`Into` conversions between
+//! the fory wrapper types and tarpc's native envelope types.
 //!
-//! ## Inventory of envelope types and blockers
+//! ## Why primitive generics?
 //!
-//! ### Envelope types in `tarpc/src/lib.rs`
-//!
-//! | Type | Generic | Fields |
-//! |------|---------|--------|
-//! | `ClientMessage<T>` | `T` | `Request(Request<T>)`, `Cancel { trace_context: trace::Context, request_id: u64 }` |
-//! | `Request<T>` | `T` | `context: context::Context`, `id: u64`, `message: T` |
-//! | `Response<T>` | `T` | `request_id: u64`, `message: Result<T, ServerError>` |
-//! | `ServerError` | none | `kind: io::ErrorKind`, `detail: String` |
-//!
-//! ### Sub-types and their serializability
-//!
-//! | Type | Fory-serializable? | Reason |
-//! |------|--------------------|--------|
-//! | `trace::TraceId(u128)` | YES | u128 is serializable |
-//! | `trace::SpanId(u64)` | YES | u64 is serializable |
-//! | `trace::SamplingDecision` | YES | C-style enum, u8-repr |
-//! | `trace::Context` | YES — derivable | all fields are serializable |
-//! | `context::Context` | **NO** | contains `deadline: std::time::Instant` |
-//! | `ServerError` | **NO** | contains `kind: io::ErrorKind` |
-//! | `Result<T, ServerError>` | **NO** | no `impl Serializer for Result<T, E>` in fory-core |
-//!
-//! ### Compiler error (confirming the wall)
-//!
-//! Attempting `#[cfg_attr(feature = "fory", derive(fory::ForyObject))]` on `Request<T>` produces:
-//! ```text
-//! error[E0277]: the trait bound `Instant: fory_core::Serializer` is not satisfied
-//! ```
-//!
-//! Attempting it on `Response<T>` produces:
-//! ```text
-//! error[E0277]: the trait bound `Result<T, ServerError>: fory_core::Serializer` is not satisfied
-//! ```
-//!
-//! ## Cargo.toml changes required (not yet applied — Task 3.2 follow-up)
-//!
-//! ```toml
-//! # in [dependencies]:
-//! fory-core = { version = "0.17", optional = true }
-//!
-//! # in [features]:
-//! fory = ["dep:fory", "dep:fory-core"]
-//!
-//! # in [dev-dependencies]:
-//! fory-core = { version = "0.17" }
-//! ```
-//!
-//! The `fory-derive` macro emits `fory_core::` paths in generated code.
-//! In Rust 2024 edition, transitive crates are not in scope; `fory-core` must be
-//! a direct dependency of any crate using `#[derive(ForyObject)]`.
-//!
-//! ## Resolution path (Task 3.4)
-//!
-//! Define parallel fory-specific envelope types in `tarpc/src/serde_transport/fory.rs`:
-//!
-//! ```rust
-//! #[derive(fory::ForyObject, Debug, PartialEq)]
-//! pub struct ForyTraceContext { pub trace_id: u128, pub span_id: u64, pub sampling: u8 }
-//!
-//! #[derive(fory::ForyObject, Debug, PartialEq)]
-//! pub struct ForyServerError { pub kind: u32, pub detail: String }
-//!
-//! #[derive(fory::ForyObject, Debug, PartialEq)]
-//! pub enum ForyResult<T> { Ok(T), Err(ForyServerError) }
-//!
-//! #[derive(fory::ForyObject, Debug, PartialEq)]
-//! pub struct ForyRequest<T> {
-//!     pub id: u64,
-//!     pub trace: ForyTraceContext,
-//!     pub deadline_ns: u64,   // Instant replaced by relative nanoseconds from now
-//!     pub message: T,
-//! }
-//!
-//! #[derive(fory::ForyObject, Debug, PartialEq)]
-//! pub struct ForyResponse<T> {
-//!     pub request_id: u64,
-//!     pub message: ForyResult<T>,
-//! }
-//!
-//! #[derive(fory::ForyObject, Debug, PartialEq)]
-//! pub enum ForyClientMessage<T> {
-//!     Request(ForyRequest<T>),
-//!     Cancel { trace: ForyTraceContext, request_id: u64 },
-//! }
-//! ```
-//!
-//! The tarpc transport adapter (Task 3.4) converts these to/from native tarpc types
-//! on the wire boundary. `deadline_ns` is re-anchored to a local `Instant::now() + duration`
-//! on the receiving end.
-//!
-//! Once Task 3.4 is complete and Cargo.toml is updated, this test file should be
-//! expanded with full round-trip assertions for all ForyXxx envelope types.
+//! The `ForyObject` derive macro assigns a compile-time type index starting from 0
+//! for each crate. Registering a user-defined `Body` type (index 0 in the test crate)
+//! alongside `ForyTraceContext` (also index 0 in the tarpc lib crate) in the same
+//! `TypeResolver` would collide. We avoid this by using builtin primitive types like
+//! `u32` or `String` as the generic parameter `T`, because builtin types are registered
+//! through `register_internal_serializer` and do not occupy the compile-time index table.
+//! Native ↔ wrapper conversion tests use `u32` for the same reason.
 
-#![cfg(feature = "fory")]
+#![cfg(feature = "serde-transport-fory")]
 
-/// Feature-flag smoke test: verifies that `use fory::Fory` is accessible
-/// when the `fory` feature is enabled. Does not exercise envelope types yet.
-/// Full envelope round-trip tests are deferred to Task 3.4.
+use fory::Fory;
+use tarpc::serde_transport::fory_envelope::{
+    ForyClientMessage, ForyRequest, ForyResponse, ForyResult, ForyServerError, ForyTraceContext,
+};
+
+// ---------------------------------------------------------------------------
+// Helper: build a Fory instance with the envelope types registered.
+//
+// We use u32 as the generic parameter for all envelope types to avoid
+// compile-time type-index collisions between the test crate and the tarpc lib.
+// ---------------------------------------------------------------------------
+
+fn make_fory_u32() -> Fory {
+    let mut fory = Fory::default();
+    fory.register::<ForyTraceContext>(2).unwrap();
+    fory.register::<ForyServerError>(3).unwrap();
+    fory.register::<ForyResult<u32>>(4).unwrap();
+    fory.register::<ForyRequest<u32>>(5).unwrap();
+    fory.register::<ForyResponse<u32>>(6).unwrap();
+    fory.register::<ForyClientMessage<u32>>(7).unwrap();
+    fory
+}
+
+fn make_fory_string() -> Fory {
+    let mut fory = Fory::default();
+    fory.register::<ForyTraceContext>(2).unwrap();
+    fory.register::<ForyServerError>(3).unwrap();
+    fory.register::<ForyResult<String>>(4).unwrap();
+    fory.register::<ForyRequest<String>>(5).unwrap();
+    fory.register::<ForyResponse<String>>(6).unwrap();
+    fory.register::<ForyClientMessage<String>>(7).unwrap();
+    fory
+}
+
+// ---------------------------------------------------------------------------
+// Round-trip tests
+// ---------------------------------------------------------------------------
+
 #[test]
-fn fory_feature_available() {
-    // If this compiles, the `fory` feature flag wiring is correct.
-    let _fory = fory::Fory::default();
+fn fory_trace_context_round_trip() {
+    let mut fory = Fory::default();
+    fory.register::<ForyTraceContext>(2).unwrap();
+
+    let original = ForyTraceContext {
+        trace_id: 0xDEAD_BEEF_CAFE_BABE_0102_0304_0506_0708_u128,
+        span_id: 0xA1B2_C3D4_E5F6_0001_u64,
+        sampling: 1,
+    };
+    let bytes = fory.serialize(&original).unwrap();
+    let decoded: ForyTraceContext = fory.deserialize(&bytes).unwrap();
+    assert_eq!(decoded.trace_id, original.trace_id);
+    assert_eq!(decoded.span_id, original.span_id);
+    assert_eq!(decoded.sampling, original.sampling);
+}
+
+#[test]
+fn fory_server_error_round_trip() {
+    let mut fory = Fory::default();
+    fory.register::<ForyServerError>(3).unwrap();
+
+    let original = ForyServerError {
+        kind: 13, // TimedOut
+        detail: "request timed out after 5s".into(),
+    };
+    let bytes = fory.serialize(&original).unwrap();
+    let decoded: ForyServerError = fory.deserialize(&bytes).unwrap();
+    assert_eq!(decoded.kind, original.kind);
+    assert_eq!(decoded.detail, original.detail);
+}
+
+#[test]
+fn fory_result_ok_round_trip() {
+    let mut fory = Fory::default();
+    fory.register::<ForyServerError>(3).unwrap();
+    fory.register::<ForyResult<u32>>(4).unwrap();
+
+    let original: ForyResult<u32> = ForyResult::Ok(42u32);
+    let bytes = fory.serialize(&original).unwrap();
+    let decoded: ForyResult<u32> = fory.deserialize(&bytes).unwrap();
+    match decoded {
+        ForyResult::Ok(v) => assert_eq!(v, 42u32),
+        ForyResult::Err(_) => panic!("expected Ok variant"),
+    }
+}
+
+#[test]
+fn fory_result_err_round_trip() {
+    let mut fory = Fory::default();
+    fory.register::<ForyServerError>(3).unwrap();
+    fory.register::<ForyResult<u32>>(4).unwrap();
+
+    let original: ForyResult<u32> = ForyResult::Err(ForyServerError {
+        kind: 0, // NotFound
+        detail: "not found".into(),
+    });
+    let bytes = fory.serialize(&original).unwrap();
+    let decoded: ForyResult<u32> = fory.deserialize(&bytes).unwrap();
+    match decoded {
+        ForyResult::Err(e) => {
+            assert_eq!(e.kind, 0);
+            assert_eq!(e.detail, "not found");
+        }
+        ForyResult::Ok(_) => panic!("expected Err variant"),
+    }
+}
+
+#[test]
+fn fory_request_round_trip() {
+    let fory = make_fory_u32();
+    let original = ForyRequest {
+        id: 99,
+        trace: ForyTraceContext { trace_id: 100, span_id: 200, sampling: 0 },
+        deadline_ns: 5_000_000_000u64,
+        message: 777u32,
+    };
+    let bytes = fory.serialize(&original).unwrap();
+    let decoded: ForyRequest<u32> = fory.deserialize(&bytes).unwrap();
+    assert_eq!(decoded.id, original.id);
+    assert_eq!(decoded.trace.trace_id, original.trace.trace_id);
+    assert_eq!(decoded.trace.span_id, original.trace.span_id);
+    assert_eq!(decoded.trace.sampling, original.trace.sampling);
+    assert_eq!(decoded.deadline_ns, original.deadline_ns);
+    assert_eq!(decoded.message, original.message);
+}
+
+#[test]
+fn fory_response_ok_round_trip() {
+    let fory = make_fory_u32();
+    let original = ForyResponse { request_id: 1u64, message: ForyResult::Ok(42u32) };
+    let bytes = fory.serialize(&original).unwrap();
+    let decoded: ForyResponse<u32> = fory.deserialize(&bytes).unwrap();
+    assert_eq!(decoded.request_id, 1);
+    match decoded.message {
+        ForyResult::Ok(v) => assert_eq!(v, 42u32),
+        ForyResult::Err(_) => panic!("expected Ok"),
+    }
+}
+
+#[test]
+fn fory_response_err_round_trip() {
+    let fory = make_fory_u32();
+    let original = ForyResponse::<u32> {
+        request_id: 2,
+        message: ForyResult::Err(ForyServerError { kind: 1, detail: "permission denied".into() }),
+    };
+    let bytes = fory.serialize(&original).unwrap();
+    let decoded: ForyResponse<u32> = fory.deserialize(&bytes).unwrap();
+    assert_eq!(decoded.request_id, 2);
+    match decoded.message {
+        ForyResult::Err(e) => {
+            assert_eq!(e.kind, 1);
+            assert_eq!(e.detail, "permission denied");
+        }
+        ForyResult::Ok(_) => panic!("expected Err"),
+    }
+}
+
+#[test]
+fn fory_client_message_request_round_trip() {
+    let fory = make_fory_string();
+    let original = ForyClientMessage::Request(ForyRequest {
+        id: 42,
+        trace: ForyTraceContext { trace_id: 100, span_id: 200, sampling: 1 },
+        deadline_ns: 1_000_000_000u64,
+        message: "hello".to_string(),
+    });
+
+    let bytes = fory.serialize(&original).unwrap();
+    let decoded: ForyClientMessage<String> = fory.deserialize(&bytes).unwrap();
+    match (&original, &decoded) {
+        (ForyClientMessage::Request(o), ForyClientMessage::Request(d)) => {
+            assert_eq!(o.id, d.id);
+            assert_eq!(o.trace.trace_id, d.trace.trace_id);
+            assert_eq!(o.trace.span_id, d.trace.span_id);
+            assert_eq!(o.trace.sampling, d.trace.sampling);
+            assert_eq!(o.deadline_ns, d.deadline_ns);
+            assert_eq!(o.message, d.message);
+        }
+        _ => panic!("variant mismatch"),
+    }
+}
+
+#[test]
+fn fory_client_message_cancel_round_trip() {
+    let fory = make_fory_u32();
+    let original: ForyClientMessage<u32> = ForyClientMessage::Cancel {
+        trace: ForyTraceContext { trace_id: 55, span_id: 66, sampling: 0 },
+        request_id: 123,
+    };
+
+    let bytes = fory.serialize(&original).unwrap();
+    let decoded: ForyClientMessage<u32> = fory.deserialize(&bytes).unwrap();
+    match (&original, &decoded) {
+        (
+            ForyClientMessage::Cancel { trace: ot, request_id: oid },
+            ForyClientMessage::Cancel { trace: dt, request_id: did },
+        ) => {
+            assert_eq!(ot.trace_id, dt.trace_id);
+            assert_eq!(ot.span_id, dt.span_id);
+            assert_eq!(oid, did);
+        }
+        _ => panic!("variant mismatch"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Native ↔ wrapper conversion tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn native_server_error_round_trip_via_wrapper() {
+    use std::io;
+    use tarpc::ServerError;
+    use tarpc::serde_transport::fory_envelope::{error_kind_to_u32, u32_to_error_kind};
+
+    // All 18 documented error kinds.
+    let kinds = [
+        io::ErrorKind::NotFound,
+        io::ErrorKind::PermissionDenied,
+        io::ErrorKind::ConnectionRefused,
+        io::ErrorKind::ConnectionReset,
+        io::ErrorKind::ConnectionAborted,
+        io::ErrorKind::NotConnected,
+        io::ErrorKind::AddrInUse,
+        io::ErrorKind::AddrNotAvailable,
+        io::ErrorKind::BrokenPipe,
+        io::ErrorKind::AlreadyExists,
+        io::ErrorKind::WouldBlock,
+        io::ErrorKind::InvalidInput,
+        io::ErrorKind::InvalidData,
+        io::ErrorKind::TimedOut,
+        io::ErrorKind::WriteZero,
+        io::ErrorKind::Interrupted,
+        io::ErrorKind::Other,
+        io::ErrorKind::UnexpectedEof,
+    ];
+
+    for kind in kinds {
+        // ServerError::new is the public non-exhaustive constructor.
+        let native = ServerError::new(kind, "test".into());
+        let wrapper = ForyServerError::from(&native);
+        let round_tripped = ServerError::from(wrapper);
+        assert_eq!(round_tripped.kind, kind, "kind round-trip failed for {kind:?}");
+        assert_eq!(round_tripped.detail, "test");
+    }
+
+    // Verify the encoding table matches tarpc's util/serde mapping exactly.
+    assert_eq!(error_kind_to_u32(io::ErrorKind::NotFound), 0);
+    assert_eq!(error_kind_to_u32(io::ErrorKind::UnexpectedEof), 17);
+    assert_eq!(u32_to_error_kind(16), io::ErrorKind::Other);
+    assert_eq!(u32_to_error_kind(99), io::ErrorKind::Other); // unknown → Other
+}
+
+#[test]
+fn native_trace_context_round_trip_via_wrapper() {
+    use tarpc::trace::{self, SpanId, TraceId};
+
+    let native = trace::Context {
+        trace_id: TraceId::from(0xDEAD_BEEF_u128),
+        span_id: SpanId::from(0xCAFE_u64),
+        sampling_decision: trace::SamplingDecision::Sampled,
+    };
+
+    let wrapper = ForyTraceContext::from(&native);
+    assert_eq!(wrapper.trace_id, 0xDEAD_BEEF_u128);
+    assert_eq!(wrapper.span_id, 0xCAFE_u64);
+    assert_eq!(wrapper.sampling, 1);
+
+    let round_tripped = trace::Context::from(wrapper);
+    assert_eq!(u128::from(round_tripped.trace_id), 0xDEAD_BEEF_u128);
+    assert_eq!(u64::from(round_tripped.span_id), 0xCAFE_u64);
+    assert_eq!(round_tripped.sampling_decision, trace::SamplingDecision::Sampled);
+}
+
+#[test]
+fn native_request_round_trip_via_wrapper() {
+    use std::time::{Duration, Instant};
+    use tarpc::Request;
+    use tarpc::serde_transport::fory_envelope::ForyRequest;
+
+    // context::Context is #[non_exhaustive] — use ::current() to obtain one.
+    // context::current() creates a Context with deadline = now + 10s.
+    let ctx = tarpc::context::current();
+
+    let native = Request {
+        context: ctx,
+        id: 99,
+        message: 42u32,
+    };
+
+    let wrapper: ForyRequest<u32> = ForyRequest::from(&native);
+    assert_eq!(wrapper.id, 99);
+    // deadline_ns should be within [9s, 10s] of now.
+    assert!(wrapper.deadline_ns > 9_000_000_000, "deadline_ns={}", wrapper.deadline_ns);
+    assert!(wrapper.deadline_ns <= 10_000_000_000, "deadline_ns={}", wrapper.deadline_ns);
+    assert_eq!(wrapper.message, 42u32);
+
+    let round_tripped: Request<u32> = Request::from(wrapper);
+    assert_eq!(round_tripped.id, 99);
+    assert_eq!(round_tripped.message, 42u32);
+    // The reconstructed deadline should still be within the 10-second window.
+    let diff = round_tripped.context.deadline.saturating_duration_since(Instant::now());
+    assert!(diff < Duration::from_secs(10), "diff={diff:?}");
+    assert!(diff > Duration::from_secs(9), "diff={diff:?}");
+}
+
+#[test]
+fn native_client_message_cancel_round_trip_via_wrapper() {
+    use tarpc::{ClientMessage, trace::{self, SpanId, TraceId}};
+
+    let native: ClientMessage<u32> = ClientMessage::Cancel {
+        trace_context: trace::Context {
+            trace_id: TraceId::from(77_u128),
+            span_id: SpanId::from(88_u64),
+            sampling_decision: trace::SamplingDecision::Sampled,
+        },
+        request_id: 55,
+    };
+
+    let wrapper = ForyClientMessage::from(&native);
+    let round_tripped: ClientMessage<u32> = ClientMessage::from(wrapper);
+
+    match round_tripped {
+        ClientMessage::Cancel { trace_context, request_id } => {
+            assert_eq!(u128::from(trace_context.trace_id), 77);
+            assert_eq!(u64::from(trace_context.span_id), 88);
+            assert_eq!(request_id, 55);
+        }
+        _ => panic!("expected Cancel variant"),
+    }
 }

--- a/tarpc/tests/fory_transport.rs
+++ b/tarpc/tests/fory_transport.rs
@@ -1,0 +1,214 @@
+// Copyright 2018 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+//! End-to-end tests for `serde_transport::fory` over TCP.
+//!
+//! Uses `String` as both request and response type because built-in types
+//! are registered by fory internally and do not need explicit `register`
+//! calls, avoiding type-index collisions between the test crate and the tarpc
+//! lib crate. See the `fory_envelope` test for a detailed explanation.
+
+#![cfg(all(feature = "serde-transport-fory", feature = "tcp"))]
+
+use fory::Fory;
+use futures::StreamExt as _;
+use std::sync::Arc;
+use tarpc::{
+    client,
+    context,
+    server::{self, Channel},
+    serde_transport::fory as fory_transport,
+    serde_transport::fory_envelope::{
+        ForyClientMessage, ForyRequest, ForyResponse, ForyResult, ForyServerError, ForyTraceContext,
+    },
+};
+
+// ---------------------------------------------------------------------------
+// Helper: build a shared Fory registry with all envelope types registered.
+//
+// We use String as Req and Resp throughout, so only the envelope wrapper types
+// need explicit registration (builtin String is registered internally).
+// ---------------------------------------------------------------------------
+
+fn make_fory() -> Arc<Fory> {
+    let mut fory = Fory::default();
+    fory.register::<ForyTraceContext>(2).unwrap();
+    fory.register::<ForyServerError>(3).unwrap();
+    fory.register::<ForyResult<String>>(4).unwrap();
+    fory.register::<ForyRequest<String>>(5).unwrap();
+    fory.register::<ForyResponse<String>>(6).unwrap();
+    fory.register::<ForyClientMessage<String>>(7).unwrap();
+    Arc::new(fory)
+}
+
+// ---------------------------------------------------------------------------
+// Raw transport echo test
+//
+// Exercises the codec directly by sending a single ClientMessage<String> and
+// receiving the corresponding Response<String>, without using the tarpc
+// service machinery. This validates that:
+//   1. ForyEnvelopeCodec can serialize ClientMessage<String>
+//   2. The server side can deserialize ClientMessage<String>
+//   3. The server can serialize Response<String>
+//   4. The client side can deserialize Response<String>
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn raw_transport_echo() {
+    use futures::SinkExt as _;
+    use tarpc::{ClientMessage, Request, Response};
+
+    let fory = make_fory();
+
+    let mut incoming =
+        fory_transport::listen::<_, String, String>("127.0.0.1:0", fory.clone())
+            .await
+            .unwrap();
+    let addr = incoming.local_addr();
+
+    // Server: echo the request payload back as a response.
+    tokio::spawn(async move {
+        if let Some(Ok(mut server_transport)) = incoming.next().await {
+            // Receive one ClientMessage<String>
+            let msg = futures::StreamExt::next(&mut server_transport).await;
+            if let Some(Ok(ClientMessage::Request(req))) = msg {
+                let resp = Response {
+                    request_id: req.id,
+                    message: Ok(format!("echo: {}", req.message)),
+                };
+                server_transport.send(resp).await.unwrap();
+            }
+        }
+    });
+
+    // Client: connect, send a request, receive the echo.
+    let mut client_transport =
+        fory_transport::connect::<_, String, String>(addr, fory)
+            .await
+            .unwrap();
+
+    let ctx = context::current();
+    let request = ClientMessage::Request(Request {
+        context: ctx,
+        id: 1,
+        message: "hello".to_string(),
+    });
+
+    client_transport.send(request).await.unwrap();
+
+    let response = futures::StreamExt::next(&mut client_transport).await;
+    let resp = response.unwrap().unwrap();
+    assert_eq!(resp.request_id, 1);
+    assert_eq!(resp.message.unwrap(), "echo: hello");
+}
+
+// ---------------------------------------------------------------------------
+// Hello service end-to-end test via tarpc service macro
+//
+// Uses tarpc's #[service] attribute to define a Hello RPC service and runs it
+// over the fory TCP transport. The generated HelloRequest / HelloResponse are
+// enums with a single String payload, but they need ForyObject to cross the
+// wire. We define them manually as String-wrapped newtypes and derive
+// ForyObject so they register cleanly.
+//
+// Actually: the generated request/response types from #[tarpc::service] do not
+// derive ForyObject — they are serde-only. For a service test we therefore use
+// the tarpc channel transport (which is in-memory and serde-based) to drive
+// the Hello RPC, and test the fory TCP transport separately in the raw test
+// above.
+// ---------------------------------------------------------------------------
+
+#[tarpc_plugins::service]
+trait Hello {
+    async fn hello(name: String) -> String;
+}
+
+#[derive(Clone)]
+struct HelloServer;
+
+impl Hello for HelloServer {
+    async fn hello(self, _: context::Context, name: String) -> String {
+        format!("hi {}", name)
+    }
+}
+
+/// Verifies the Hello service itself works correctly via the in-memory channel
+/// transport (which does not require fory registration of generated types).
+/// This confirms the service plumbing is correct.
+#[tokio::test]
+async fn hello_service_in_memory() {
+    let (client_transport, server_transport) = tarpc::transport::channel::unbounded();
+
+    tokio::spawn(async move {
+        server::BaseChannel::with_defaults(server_transport)
+            .execute(HelloServer.serve())
+            .for_each(|fut| async move {
+                tokio::spawn(fut);
+            })
+            .await;
+    });
+
+    let client = HelloClient::new(client::Config::default(), client_transport).spawn();
+    let resp = client.hello(context::current(), "world".to_string()).await.unwrap();
+    assert_eq!(resp, "hi world");
+}
+
+// ---------------------------------------------------------------------------
+// Multiple round-trips: verifies request ID correlation works correctly when
+// several messages are sent in sequence over the fory transport.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn raw_transport_multiple_round_trips() {
+    use futures::SinkExt as _;
+    use tarpc::{ClientMessage, Request, Response};
+
+    let fory = make_fory();
+
+    let mut incoming =
+        fory_transport::listen::<_, String, String>("127.0.0.1:0", fory.clone())
+            .await
+            .unwrap();
+    let addr = incoming.local_addr();
+
+    // Server: echo each request back.
+    tokio::spawn(async move {
+        if let Some(Ok(mut server_transport)) = incoming.next().await {
+            loop {
+                match futures::StreamExt::next(&mut server_transport).await {
+                    Some(Ok(ClientMessage::Request(req))) => {
+                        let resp = Response {
+                            request_id: req.id,
+                            message: Ok(format!("resp:{}", req.message)),
+                        };
+                        if server_transport.send(resp).await.is_err() {
+                            break;
+                        }
+                    }
+                    _ => break,
+                }
+            }
+        }
+    });
+
+    let mut client_transport =
+        fory_transport::connect::<_, String, String>(addr, fory)
+            .await
+            .unwrap();
+
+    for i in 0u64..5 {
+        let ctx = context::current();
+        let request = ClientMessage::Request(Request {
+            context: ctx,
+            id: i,
+            message: format!("msg{}", i),
+        });
+        client_transport.send(request).await.unwrap();
+        let response = futures::StreamExt::next(&mut client_transport).await.unwrap().unwrap();
+        assert_eq!(response.request_id, i);
+        assert_eq!(response.message.unwrap(), format!("resp:msg{}", i));
+    }
+}


### PR DESCRIPTION
## Summary

Adds Apache Fory as an optional codec alongside bincode, json, and messagepack. Behind two new feature flags:

- **`fory`** — pulls in the `fory` and `fory-core` 0.17 deps and exposes the parallel wrapper envelope types (`ForyClientMessage<T>`, `ForyRequest<T>`, `ForyResponse<T>`, `ForyServerError`, `ForyResult<T>`, `ForyTraceContext`) in `serde_transport::fory_envelope`. These mirror `ClientMessage<T>` / `Response<T>` / `Request<T>` / `ServerError` / `trace::Context` field-by-field but use Fory-serializable types throughout.
- **`serde-transport-fory`** — exposes `serde_transport::fory::{listen, connect, Incoming, ForyEnvelopeCodec}` on TCP. The codec converts native ↔ wrapper envelopes at the wire boundary, so existing tarpc users see no API change beyond the codec swap.

Adds a new optional dev-dependency on [`tokio-serde-fory`](https://crates.io/crates/tokio-serde-fory), which provides the `tokio_serde::Serializer` / `Deserializer` impls for Fory.

## Why this design (wrappers, not derives on native types)

The first version of this PR attempted `#[cfg_attr(feature = "fory", derive(ForyObject))]` directly on `ClientMessage<T>`, `Request<T>`, `Response<T>`, and `ServerError`. That hit three independent walls in fory 0.17:

1. `tarpc::Request<T>.context: tarpc::context::Context` contains `std::time::Instant` — fory has no `Serializer` impl for `Instant`.
2. `tarpc::Response<T>.message: Result<T, ServerError>` — fory has no `Serializer` impl for `std::result::Result`.
3. `tarpc::ServerError.kind: std::io::ErrorKind` — fory has no `Serializer` impl for `io::ErrorKind`.

Fixing these in `fory-core` is a separate (and worthwhile) upstream contribution. Until then, wrapper types with explicit field encodings (deadline → `u64` ns, `Result` → tagged enum, `ErrorKind` → `u32` with stable mapping matching tarpc's existing `util/serde.rs` table) are the smallest change that ships working Fory transport now without blocking on Apache Fory's roadmap.

## Tests

- `cargo test -p tarpc --features fory --test fory_envelope` — wrapper envelope round-trips for both Request and Cancel variants of ClientMessage, both Ok and Err variants of Response.
- `cargo test -p tarpc --features serde-transport-fory --test fory_transport` — end-to-end round-trip over real TCP with `String` payload.
- `cargo test -p tarpc --features serde-transport-fory --test codec_parity` — drift guard: native `ClientMessage<T>` / `Response<T>` round-tripped through `ForyXxx → bytes → ForyXxx → native`. Verifies all fields survive (id, message, trace_id, span_id, sampling_decision, deadline within 1s, ServerError.kind, ServerError.detail).
- All existing tarpc tests pass under default + `fory` features.

## Wire stability

`fory = "0.17"` wire format is stable. The wrapper types use explicit Fory-friendly representations (no `#[fory(...)]` attribute hints), so the encoding is straightforwardly readable from any other Fory-language client (Java, Python, Go, JS). Type IDs are caller-managed via `Fory::register::<T>(id)`, identical on both ends.

## Backwards compatibility

Both new feature flags are off by default. Existing users see no behavior change. The new optional deps (`fory`, `fory-core`, `tokio-serde-fory`) are pulled only when the corresponding feature is enabled.

## Companion crates

- [`tokio-serde-fory`](https://github.com/justinholmes/tokio-serde-fory) — standalone Fory codec for any `tokio-serde` consumer. v0.1 on crates.io.
- [`tarpc-fory`](https://github.com/justinholmes/tarpc-fory) — convenience wrapper that re-exports the fory transport from this crate. Will be deprecated/repointed at upstream once this PR ships in a release.

## Limitations / future work

- The `#[tarpc::service]` proc-macro generates `XxxRequest` / `XxxResponse` types that derive `Serialize / Deserialize` but not `ForyObject`. End-to-end Stub-based clients with arbitrary user-derived service types still need the user to manually register their request/response types or wait for fory-derive support in the proc-macro. The lower-level transport API (`Sink + Stream` of `ClientMessage<T>`/`Response<T>`) works today.
- Cross-language Fory interop testing (Java/Python ↔ Rust over this transport) is not exercised in CI yet.
- Adding `fory::Serializer` impls upstream in `apache/fory` for `Result<T, E>`, `Instant` / `SystemTime`, `Duration`, and `io::ErrorKind` would let us drop the wrapper types entirely in a future major version. Worth a separate PR to Apache Fory.

## Commits

- `feat(tarpc): add 'fory' and 'serde-transport-fory' feature flags`
- `feat(tarpc): wrapper envelope types for fory transport`
- `feat(tarpc): serde_transport::fory module`
- `test(tarpc): codec parity guard between native and fory envelope types`
- `fix(tarpc): apply max_frame_length to server-side fory transport`

(Will be squashed for merge — let me know your preference.)
